### PR TITLE
Switch from procinfo to procfs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["nightly"]
 default = ["protobuf"]
 nightly = ["libc"]
 push = ["reqwest", "libc", "protobuf"]
-process = ["libc", "procinfo"]
+process = ["libc", "procfs"]
 gen = ["protobuf-codegen-pure"]
 
 [dependencies]
@@ -35,7 +35,7 @@ spin = "0.5.2"
 reqwest = { version = "0.9.5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-procinfo = { version = "0.4", optional = true }
+procfs = { version = "0.7", optional = true, default-features = false }
 
 [dev-dependencies]
 getopts = "0.2"


### PR DESCRIPTION
This commit doesn't add any new features, but allows future commits to
use features in procfs that are missing from procinfo.  Also hopefully rust-prometheus won't have to maintain as much code to deal with process info.

The idea for this change came from @brndnmtthws, who wanted to use some features in procfs that are missing from procinfo.  I haven't added these features yet, but if this PR is accepted, I can help with that work too.   Disclaimer: I am the author of the procfs crate.

Closes #272