### PR TITLE
use Cow where necessary

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -48,7 +49,7 @@ impl<P: Atomic> Clone for GenericCounter<P> {
 
 impl<P: Atomic> GenericCounter<P> {
     /// Create a [`GenericCounter`](::core::GenericCounter) with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
+    pub fn new<S: Into<Cow<'static, str>>>(name: S, help: S) -> Result<Self> {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }
@@ -159,8 +160,9 @@ impl<P: Atomic> GenericCounterVec<P> {
     /// Create a new [`GenericCounterVec`](::core::GenericCounterVec) based on the provided
     /// [`Opts`](::Opts) and partitioned by the given label names. At least one label name must be
     /// provided.
-    pub fn new(opts: Opts, label_names: &[&str]) -> Result<Self> {
-        let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
+    pub fn new(opts: Opts, label_names: &[&'static str]) -> Result<Self> {
+        let variable_names: Vec<Cow<'static, str>> =
+            label_names.iter().map(|s| Cow::Borrowed(*s)).collect();
         let opts = opts.variable_labels(variable_names);
         let metric_vec =
             MetricVec::create(proto::MetricType::COUNTER, CounterVecBuilder::new(), opts)?;
@@ -275,7 +277,7 @@ impl<P: Atomic> GenericLocalCounterVec<P> {
 
     /// Get a [`GenericLocalCounter`](::core::GenericLocalCounter) by label values.
     /// See more [MetricVec::with_label_values](::core::MetricVec::with_label_values).
-    pub fn with_label_values<'a>(&'a mut self, vals: &[&str]) -> &'a mut GenericLocalCounter<P> {
+    pub fn with_label_values(&mut self, vals: &[&str]) -> &mut GenericLocalCounter<P> {
         let hash = self.vec.v.hash_label_values(vals).unwrap();
         let vec = &self.vec;
         self.local

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -47,7 +48,7 @@ impl<P: Atomic> Clone for GenericGauge<P> {
 
 impl<P: Atomic> GenericGauge<P> {
     /// Create a [`GenericGauge`](::core::GenericGauge) with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
+    pub fn new<S: Into<Cow<'static, str>>>(name: S, help: S) -> Result<Self> {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }
@@ -162,8 +163,8 @@ impl<P: Atomic> GenericGaugeVec<P> {
     /// Create a new [`GenericGaugeVec`](::core::GenericGaugeVec) based on the provided
     /// [`Opts`](::Opts) and partitioned by the given label names. At least one label name must
     /// be provided.
-    pub fn new(opts: Opts, label_names: &[&str]) -> Result<Self> {
-        let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
+    pub fn new(opts: Opts, label_names: &[&'static str]) -> Result<Self> {
+        let variable_names = label_names.iter().map(|s| Cow::Borrowed(*s)).collect();
         let opts = opts.variable_labels(variable_names);
         let metric_vec = MetricVec::create(proto::MetricType::GAUGE, GaugeVecBuilder::new(), opts)?;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,7 @@
 /// assert!(labels.is_empty());
 /// # }
 /// ```
+///
 #[macro_export]
 macro_rules! labels {
     ( $( $ KEY : expr => $ VALUE : expr ),* $(,)? ) => {
@@ -80,12 +81,14 @@ macro_rules! opts {
     ( $ NAME : expr , $ HELP : expr $ ( , $ CONST_LABELS : expr ) * ) => {
         {
             use std::collections::HashMap;
+            use std::borrow::Cow;
 
             let opts = $crate::Opts::new($NAME, $HELP);
-            let lbs = HashMap::<String, String>::new();
+            let lbs = HashMap::<Cow<'static, str>, Cow<'static, str>>::new();
             $(
                 let mut lbs = lbs;
-                lbs.extend($CONST_LABELS.iter().map(|(k, v)| ((*k).into(), (*v).into())));
+                lbs.extend($CONST_LABELS.iter().map(|(k, v)| (Cow::Borrowed(*k), Cow::Borrowed
+        (*v))));
             )*
 
             opts.const_labels(lbs)
@@ -100,6 +103,7 @@ macro_rules! opts {
 /// ```
 /// # #[macro_use] extern crate prometheus;
 /// # use prometheus::linear_buckets;
+/// # use std::borrow::Cow;
 /// # fn main() {
 /// let name = "test_histogram_opts";
 /// let help = "test opts help";
@@ -116,7 +120,7 @@ macro_rules! opts {
 /// let opts = histogram_opts!(name,
 ///                            help,
 ///                            vec![1.0, 2.0],
-///                            labels!{"key".to_string() => "value".to_string(),});
+///                            labels!{Cow::Borrowed("key")=> Cow::Borrowed("value"),});
 /// assert_eq!(opts.common_opts.name, name);
 /// assert_eq!(opts.common_opts.help, help);
 /// assert_eq!(opts.buckets.len(), 2);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::{Cow, ToOwned};
 use std::cmp::{Eq, Ord, Ordering, PartialOrd};
 use std::collections::HashMap;
 
@@ -44,25 +45,25 @@ pub struct Opts {
     /// "_"). Only Name is mandatory, the others merely help structuring the
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
-    pub namespace: String,
+    pub namespace: Cow<'static, str>,
     /// namespace, subsystem, and name are components of the fully-qualified
     /// name of the [`Metric`](::core::Metric) (created by joining these components with
     /// "_"). Only Name is mandatory, the others merely help structuring the
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
-    pub subsystem: String,
+    pub subsystem: Cow<'static, str>,
     /// namespace, subsystem, and name are components of the fully-qualified
     /// name of the [`Metric`](::core::Metric) (created by joining these components with
     /// "_"). Only Name is mandatory, the others merely help structuring the
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
-    pub name: String,
+    pub name: Cow<'static, str>,
 
     /// help provides information about this metric. Mandatory!
     ///
     /// Metrics with the same fully-qualified name must have the same Help
     /// string.
-    pub help: String,
+    pub help: Cow<'static, str>,
 
     /// const_labels are used to attach fixed labels to this metric. Metrics
     /// with the same fully-qualified name must have the same label names in
@@ -82,7 +83,7 @@ pub struct Opts {
     /// If the value of a label never changes (not even between binaries),
     /// that label most likely should not be a label at all (but part of the
     /// metric name).
-    pub const_labels: HashMap<String, String>,
+    pub const_labels: HashMap<Cow<'static, str>, Cow<'static, str>>,
 
     /// variable_labels contains names of labels for which the metric maintains
     /// variable values. Metrics with the same fully-qualified name must have
@@ -90,15 +91,15 @@ pub struct Opts {
     ///
     /// Note that variable_labels is used in `MetricVec`. To create a single
     /// metric must leave it empty.
-    pub variable_labels: Vec<String>,
+    pub variable_labels: Vec<Cow<'static, str>>,
 }
 
 impl Opts {
     /// `new` creates the Opts with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Opts {
+    pub fn new<S: Into<Cow<'static, str>>>(name: S, help: S) -> Opts {
         Opts {
-            namespace: "".to_owned(),
-            subsystem: "".to_owned(),
+            namespace: "".into(),
+            subsystem: "".into(),
             name: name.into(),
             help: help.into(),
             const_labels: HashMap::new(),
@@ -107,44 +108,47 @@ impl Opts {
     }
 
     /// `namespace` sets the namespace.
-    pub fn namespace<S: Into<String>>(mut self, namespace: S) -> Self {
+    pub fn namespace<S: Into<Cow<'static, str>>>(mut self, namespace: S) -> Self {
         self.namespace = namespace.into();
         self
     }
 
     /// `subsystem` sets the sub system.
-    pub fn subsystem<S: Into<String>>(mut self, subsystem: S) -> Self {
+    pub fn subsystem<S: Into<Cow<'static, str>>>(mut self, subsystem: S) -> Self {
         self.subsystem = subsystem.into();
         self
     }
 
     /// `const_labels` sets the const labels.
-    pub fn const_labels(mut self, const_labels: HashMap<String, String>) -> Self {
+    pub fn const_labels(
+        mut self,
+        const_labels: HashMap<Cow<'static, str>, Cow<'static, str>>,
+    ) -> Self {
         self.const_labels = const_labels;
         self
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
+    pub fn const_label<S: Into<Cow<'static, str>>>(mut self, name: S, value: S) -> Self {
         self.const_labels.insert(name.into(), value.into());
         self
     }
 
     /// `variable_labels` sets the variable labels.
-    pub fn variable_labels(mut self, variable_labels: Vec<String>) -> Self {
+    pub fn variable_labels(mut self, variable_labels: Vec<Cow<'static, str>>) -> Self {
         self.variable_labels = variable_labels;
         self
     }
 
     /// `variable_label` adds a variable label.
-    pub fn variable_label<S: Into<String>>(mut self, name: S) -> Self {
+    pub fn variable_label<S: Into<Cow<'static, str>>>(mut self, name: S) -> Self {
         self.variable_labels.push(name.into());
         self
     }
 
     /// `fq_name` returns the fq_name.
-    pub fn fq_name(&self) -> String {
-        build_fq_name(&self.namespace, &self.subsystem, &self.name)
+    pub fn fq_name(&self) -> Cow<'static, str> {
+        Cow::from(build_fq_name(&self.namespace, &self.subsystem, &self.name))
     }
 }
 

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -15,6 +15,7 @@
 //!
 //! This module only supports **Linux** platform.
 
+use std::borrow::Cow;
 use std::sync::Mutex;
 
 use crate::counter::Counter;
@@ -46,7 +47,7 @@ pub struct ProcessCollector {
 
 impl ProcessCollector {
     /// Create a `ProcessCollector` with the given process id and namespace.
-    pub fn new<S: Into<String>>(pid: pid_t, namespace: S) -> ProcessCollector {
+    pub fn new<S: Into<Cow<'static, str>>>(pid: pid_t, namespace: S) -> ProcessCollector {
         let namespace = namespace.into();
         let mut descs = Vec::new();
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::btree_map::Entry as BEntry;
 use std::collections::hash_map::Entry as HEntry;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -25,7 +26,7 @@ use crate::proto;
 
 struct RegistryCore {
     pub collectors_by_id: HashMap<u64, Box<dyn Collector>>,
-    pub dim_hashes_by_name: HashMap<String, u64>,
+    pub dim_hashes_by_name: HashMap<Cow<'static, str>, u64>,
     pub desc_ids: HashSet<u64>,
     /// Optional common labels for all registered collectors.
     pub labels: Option<HashMap<String, String>>,

--- a/src/value.rs
+++ b/src/value.rs
@@ -125,8 +125,8 @@ impl<P: Atomic> Value<P> {
 
     pub fn collect(&self) -> MetricFamily {
         let mut m = MetricFamily::default();
-        m.set_name(self.desc.fq_name.clone());
-        m.set_help(self.desc.help.clone());
+        m.set_name(self.desc.fq_name.to_string());
+        m.set_help(self.desc.help.to_string());
         m.set_field_type(self.val_type.metric_type());
         m.set_metric(from_vec!(vec![self.metric()]));
         m
@@ -146,7 +146,7 @@ pub fn make_label_pairs(desc: &Desc, label_values: &[&str]) -> Vec<LabelPair> {
     let mut label_pairs = Vec::with_capacity(total_len);
     for (i, n) in desc.variable_labels.iter().enumerate() {
         let mut label_pair = LabelPair::default();
-        label_pair.set_name(n.clone());
+        label_pair.set_name(n.to_string());
         label_pair.set_value(label_values[i].to_owned());
         label_pairs.push(label_pair);
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -47,8 +47,8 @@ pub(crate) struct MetricVecCore<T: MetricVecBuilder> {
 impl<T: MetricVecBuilder> MetricVecCore<T> {
     pub fn collect(&self) -> MetricFamily {
         let mut m = MetricFamily::default();
-        m.set_name(self.desc.fq_name.clone());
-        m.set_help(self.desc.help.clone());
+        m.set_name(self.desc.fq_name.to_string());
+        m.set_help(self.desc.help.to_string());
         m.set_field_type(self.metric_type);
 
         let children = self.children.read();


### PR DESCRIPTION
Signed-off-by: fredchenbj <cfworking@163.com>

for https://github.com/tikv/rust-prometheus/issues/282 and https://github.com/tikv/tikv/issues/5705, try to use Cow<'static, str> to improve the memory usage.

`make all` passed. 