### PR TITLE
Correct intra-doc links

### DIFF
--- a/src/atomic64.rs
+++ b/src/atomic64.rs
@@ -7,7 +7,7 @@ use std::ops::*;
 use std::sync::atomic::{AtomicI64 as StdAtomicI64, AtomicU64 as StdAtomicU64, Ordering};
 
 /// An interface for numbers. Used to generically model float metrics and integer metrics, i.e.
-/// [`Counter`](::Counter) and [`IntCounter`](::IntCounter).
+/// [`Counter`](crate::Counter) and [`IntCounter`](crate::Counter).
 pub trait Number:
     Sized + AddAssign + SubAssign + PartialOrd + PartialEq + Copy + Send + Sync
 {
@@ -54,7 +54,7 @@ impl Number for f64 {
 }
 
 /// An interface for atomics. Used to generically model float metrics and integer metrics, i.e.
-/// [`Counter`](::Counter) and [`IntCounter`](::IntCounter).
+/// [`Counter`](crate::Counter) and [`IntCounter`](crate::IntCounter).
 pub trait Atomic: Send + Sync {
     /// The numeric type associated with this atomic.
     type T: Number;

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -14,16 +14,16 @@ use crate::proto;
 use crate::value::{Value, ValueType};
 use crate::vec::{MetricVec, MetricVecBuilder};
 
-/// The underlying implementation for [`Counter`](::Counter) and [`IntCounter`](::IntCounter).
+/// The underlying implementation for [`Counter`] and [`IntCounter`].
 #[derive(Debug)]
 pub struct GenericCounter<P: Atomic> {
     v: Arc<Value<P>>,
 }
 
-/// A [`Metric`](::core::Metric) represents a single numerical value that only ever goes up.
+/// A [`Metric`] represents a single numerical value that only ever goes up.
 pub type Counter = GenericCounter<AtomicF64>;
 
-/// The integer version of [`Counter`](::Counter). Provides better performance if metric values
+/// The integer version of [`Counter`]. Provides better performance if metric values
 /// are all integers.
 pub type IntCounter = GenericCounter<AtomicI64>;
 
@@ -36,13 +36,13 @@ impl<P: Atomic> Clone for GenericCounter<P> {
 }
 
 impl<P: Atomic> GenericCounter<P> {
-    /// Create a [`GenericCounter`](::core::GenericCounter) with the `name` and `help` arguments.
+    /// Create a [`GenericCounter`] with the `name` and `help` arguments.
     pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }
 
-    /// Create a [`GenericCounter`](::core::GenericCounter) with the `opts` options.
+    /// Create a [`GenericCounter`] with the `opts` options.
     pub fn with_opts(opts: Opts) -> Result<Self> {
         Self::with_opts_and_label_values(&opts, &[])
     }
@@ -81,7 +81,7 @@ impl<P: Atomic> GenericCounter<P> {
         self.v.set(P::T::from_i64(0))
     }
 
-    /// Return a [`GenericLocalCounter`](::core::GenericLocalCounter) for single thread usage.
+    /// Return a [`GenericLocalCounter`] for single thread usage.
     pub fn local(&self) -> GenericLocalCounter<P> {
         GenericLocalCounter::new(self.clone())
     }
@@ -131,22 +131,22 @@ impl<P: Atomic> MetricVecBuilder for CounterVecBuilder<P> {
     }
 }
 
-/// The underlying implementation for [`CounterVec`](::CounterVec) and [`IntCounterVec`](::IntCounterVec).
+/// The underlying implementation for [`CounterVec`] and [`IntCounterVec`].
 pub type GenericCounterVec<P> = MetricVec<CounterVecBuilder<P>>;
 
-/// A [`Collector`](::core::Collector) that bundles a set of [`Counter`](::Counter)s that all share
-/// the same [`Desc`](::core::Desc), but have different values for their variable labels. This is
+/// A [`Collector`] that bundles a set of [`Counter`]s that all share
+/// the same [`Desc`], but have different values for their variable labels. This is
 /// used if you want to count the same thing partitioned by various dimensions
 /// (e.g. number of HTTP requests, partitioned by response code and method).
 pub type CounterVec = GenericCounterVec<AtomicF64>;
 
-/// The integer version of [`CounterVec`](::CounterVec). Provides better performance if metric
+/// The integer version of [`CounterVec`]. Provides better performance if metric
 /// values are all integers.
 pub type IntCounterVec = GenericCounterVec<AtomicI64>;
 
 impl<P: Atomic> GenericCounterVec<P> {
-    /// Create a new [`GenericCounterVec`](::core::GenericCounterVec) based on the provided
-    /// [`Opts`](::Opts) and partitioned by the given label names. At least one label name must be
+    /// Create a new [`GenericCounterVec`] based on the provided
+    /// [`Opts`] and partitioned by the given label names. At least one label name must be
     /// provided.
     pub fn new(opts: Opts, label_names: &[&str]) -> Result<Self> {
         let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
@@ -157,24 +157,24 @@ impl<P: Atomic> GenericCounterVec<P> {
         Ok(metric_vec as Self)
     }
 
-    /// Return a [`GenericLocalCounterVec`](::core::GenericLocalCounterVec) for single thread usage.
+    /// Return a [`GenericLocalCounterVec`] for single thread usage.
     pub fn local(&self) -> GenericLocalCounterVec<P> {
         GenericLocalCounterVec::new(self.clone())
     }
 }
 
-/// The underlying implementation for [`LocalCounter`](::local::LocalCounter)
-/// and [`LocalIntCounter`](::local::LocalIntCounter).
+/// The underlying implementation for [`LocalCounter`]
+/// and [`LocalIntCounter`].
 #[derive(Debug)]
 pub struct GenericLocalCounter<P: Atomic> {
     counter: GenericCounter<P>,
     val: RefCell<P::T>,
 }
 
-/// An unsync [`Counter`](::Counter).
+/// An unsync [`Counter`].
 pub type LocalCounter = GenericLocalCounter<AtomicF64>;
 
-/// The integer version of [`LocalCounter`](::local::LocalCounter). Provides better performance
+/// The integer version of [`LocalCounter`]. Provides better performance
 /// if metric values are all integers.
 pub type LocalIntCounter = GenericLocalCounter<AtomicI64>;
 
@@ -215,7 +215,7 @@ impl<P: Atomic> GenericLocalCounter<P> {
         *self.val.borrow_mut() = P::T::from_i64(0);
     }
 
-    /// Flush the local metrics to the [`Counter`](::Counter).
+    /// Flush the local metrics to the [`Counter`].
     #[inline]
     pub fn flush(&self) {
         if *self.val.borrow() == P::T::from_i64(0) {
@@ -240,8 +240,8 @@ impl<P: Atomic> Clone for GenericLocalCounter<P> {
     }
 }
 
-/// The underlying implementation for [`LocalCounterVec`](::local::LocalCounterVec)
-/// and [`LocalIntCounterVec`](::local::LocalIntCounterVec).
+/// The underlying implementation for [`LocalCounterVec`]
+/// and [`LocalIntCounterVec`].
 pub struct GenericLocalCounterVec<P: Atomic> {
     vec: GenericCounterVec<P>,
     local: HashMap<u64, GenericLocalCounter<P>>,
@@ -257,10 +257,10 @@ impl<P: Atomic> std::fmt::Debug for GenericLocalCounterVec<P> {
     }
 }
 
-/// An unsync [`CounterVec`](::CounterVec).
+/// An unsync [`CounterVec`].
 pub type LocalCounterVec = GenericLocalCounterVec<AtomicF64>;
 
-/// The integer version of [`LocalCounterVec`](::local::LocalCounterVec).
+/// The integer version of [`LocalCounterVec`].
 /// Provides better performance if metric values are all integers.
 pub type LocalIntCounterVec = GenericLocalCounterVec<AtomicI64>;
 
@@ -270,8 +270,8 @@ impl<P: Atomic> GenericLocalCounterVec<P> {
         Self { vec, local }
     }
 
-    /// Get a [`GenericLocalCounter`](::core::GenericLocalCounter) by label values.
-    /// See more [MetricVec::with_label_values](::core::MetricVec::with_label_values).
+    /// Get a [`GenericLocalCounter`] by label values.
+    /// See more [MetricVec::with_label_values].
     pub fn with_label_values<'a>(&'a mut self, vals: &[&str]) -> &'a mut GenericLocalCounter<P> {
         let hash = self.vec.v.hash_label_values(vals).unwrap();
         let vec = &self.vec;
@@ -280,15 +280,15 @@ impl<P: Atomic> GenericLocalCounterVec<P> {
             .or_insert_with(|| vec.with_label_values(vals).local())
     }
 
-    /// Remove a [`GenericLocalCounter`](::core::GenericLocalCounter) by label values.
-    /// See more [MetricVec::remove_label_values](::core::MetricVec::remove_label_values).
+    /// Remove a [`GenericLocalCounter`] by label values.
+    /// See more [MetricVec::remove_label_values].
     pub fn remove_label_values(&mut self, vals: &[&str]) -> Result<()> {
         let hash = self.vec.v.hash_label_values(vals)?;
         self.local.remove(&hash);
         self.vec.v.delete_label_values(vals)
     }
 
-    /// Flush the local metrics to the [`CounterVec`](::CounterVec) metric.
+    /// Flush the local metrics to the [`CounterVec`] metric.
     pub fn flush(&self) {
         for h in self.local.values() {
             h.flush();

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -227,7 +227,7 @@ impl<P: Atomic> GenericLocalCounter<P> {
 }
 
 impl<P: Atomic> LocalMetric for GenericLocalCounter<P> {
-    /// Flush the local metrics to the [`Counter`](::Counter).
+    /// Flush the local metrics to the [`Counter`].
     #[inline]
     fn flush(&self) {
         GenericLocalCounter::flush(self);
@@ -297,7 +297,7 @@ impl<P: Atomic> GenericLocalCounterVec<P> {
 }
 
 impl<P: Atomic> LocalMetric for GenericLocalCounterVec<P> {
-    /// Flush the local metrics to the [`CounterVec`](::CounterVec) metric.
+    /// Flush the local metrics to the [`CounterVec`] metric.
     fn flush(&self) {
         GenericLocalCounterVec::flush(self);
     }

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -54,9 +54,9 @@ fn is_valid_label_name(name: &str) -> bool {
     name.starts_with(valid_start) && !name.contains(|c| !valid_char(c))
 }
 
-/// The descriptor used by every Prometheus [`Metric`](::core::Metric). It is essentially
+/// The descriptor used by every Prometheus [`Metric`](crate::core::Metric). It is essentially
 /// the immutable meta-data of a metric. The normal metric implementations
-/// included in this package manage their [`Desc`](::core::Desc) under the hood.
+/// included in this package manage their [`Desc`] under the hood.
 ///
 /// Descriptors registered with the same registry have to fulfill certain
 /// consistency and uniqueness criteria if they share the same fully-qualified
@@ -89,7 +89,7 @@ pub struct Desc {
 }
 
 impl Desc {
-    /// Initializes a new [`Desc`](::core::Desc). Errors are recorded in the Desc
+    /// Initializes a new [`Desc`]. Errors are recorded in the Desc
     /// and will be reported on registration time. variableLabels and constLabels can
     /// be nil if no such labels should be set. fqName and help must not be empty.
     pub fn new(
@@ -195,9 +195,9 @@ impl Desc {
     }
 }
 
-/// An interface for describing the immutable meta-data of a [`Metric`](::core::Metric).
+/// An interface for describing the immutable meta-data of a [`Metric`](crate::core::Metric).
 pub trait Describer {
-    /// `describe` returns a [`Desc`](::core::Desc).
+    /// `describe` returns a [`Desc`].
     fn describe(&self) -> Result<Desc>;
 }
 

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -14,8 +14,8 @@ pub const PROTOBUF_FORMAT: &str = "application/vnd.google.protobuf; \
                                    proto=io.prometheus.client.MetricFamily; \
                                    encoding=delimited";
 
-/// An implementation of an [`Encoder`](::Encoder) that converts a `MetricFamily` proto message
-/// into the binary wire format of protobuf.
+/// An implementation of an [`Encoder`] that converts a [`MetricFamily`] proto
+/// message into the binary wire format of protobuf.
 #[derive(Debug, Default)]
 pub struct ProtobufEncoder;
 

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -13,7 +13,7 @@ pub const TEXT_FORMAT: &str = "text/plain; version=0.0.4";
 
 const POSITIVE_INF: &str = "+Inf";
 
-/// An implementation of an [`Encoder`](::Encoder) that converts a `MetricFamily` proto message
+/// An implementation of an [`Encoder`] that converts a [`MetricFamily`] proto message
 /// into text format.
 #[derive(Debug, Default)]
 pub struct TextEncoder;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,7 +22,7 @@ pub enum Error {
     /// An error containing a [`std::io::Error`].
     #[error("Io error: {0}")]
     Io(#[from] std::io::Error),
-    /// An error containing a [`protobuf::Error`].
+    /// An error containing a [`protobuf::error::ProtobufError`].
     #[cfg(feature = "protobuf")]
     #[error("Protobuf error: {0}")]
     Protobuf(#[from] protobuf::error::ProtobufError),

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -12,17 +12,17 @@ use crate::proto;
 use crate::value::{Value, ValueType};
 use crate::vec::{MetricVec, MetricVecBuilder};
 
-/// The underlying implementation for [`Gauge`](::Gauge) and [`IntGauge`](::IntGauge).
+/// The underlying implementation for [`Gauge`] and [`IntGauge`].
 #[derive(Debug)]
 pub struct GenericGauge<P: Atomic> {
     v: Arc<Value<P>>,
 }
 
-/// A [`Metric`](::core::Metric) represents a single numerical value that can arbitrarily go up
+/// A [`Metric`] represents a single numerical value that can arbitrarily go up
 /// and down.
 pub type Gauge = GenericGauge<AtomicF64>;
 
-/// The integer version of [`Gauge`](::Gauge). Provides better performance if metric values are
+/// The integer version of [`Gauge`]. Provides better performance if metric values are
 /// all integers.
 pub type IntGauge = GenericGauge<AtomicI64>;
 
@@ -35,13 +35,13 @@ impl<P: Atomic> Clone for GenericGauge<P> {
 }
 
 impl<P: Atomic> GenericGauge<P> {
-    /// Create a [`GenericGauge`](::core::GenericGauge) with the `name` and `help` arguments.
+    /// Create a [`GenericGauge`] with the `name` and `help` arguments.
     pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }
 
-    /// Create a [`GenericGauge`](::core::GenericGauge) with the `opts` options.
+    /// Create a [`GenericGauge`] with the `opts` options.
     pub fn with_opts(opts: Opts) -> Result<Self> {
         Self::with_opts_and_label_values(&opts, &[])
     }
@@ -134,22 +134,22 @@ impl<P: Atomic> MetricVecBuilder for GaugeVecBuilder<P> {
     }
 }
 
-/// The underlying implementation for [`GaugeVec`](::GaugeVec) and [`IntGaugeVec`](::IntGaugeVec).
+/// The underlying implementation for [`GaugeVec`] and [`IntGaugeVec`].
 pub type GenericGaugeVec<P> = MetricVec<GaugeVecBuilder<P>>;
 
-/// A [`Collector`](::core::Collector) that bundles a set of [`Gauge`](::Gauge)s that all share
-/// the same [`Desc`](::core::Desc), but have different values for their variable labels. This is
+/// A [`Collector`] that bundles a set of [`Gauge`]s that all share
+/// the same [`Desc`], but have different values for their variable labels. This is
 /// used if you want to count the same thing partitioned by various dimensions
 /// (e.g. number of operations queued, partitioned by user and operation type).
 pub type GaugeVec = GenericGaugeVec<AtomicF64>;
 
-/// The integer version of [`GaugeVec`](::GaugeVec). Provides better performance if metric values
+/// The integer version of [`GaugeVec`]. Provides better performance if metric values
 /// are all integers.
 pub type IntGaugeVec = GenericGaugeVec<AtomicI64>;
 
 impl<P: Atomic> GenericGaugeVec<P> {
-    /// Create a new [`GenericGaugeVec`](::core::GenericGaugeVec) based on the provided
-    /// [`Opts`](::Opts) and partitioned by the given label names. At least one label name must
+    /// Create a new [`GenericGaugeVec`] based on the provided
+    /// [`Opts`] and partitioned by the given label names. At least one label name must
     /// be provided.
     pub fn new(opts: Opts, label_names: &[&str]) -> Result<Self> {
         let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -15,7 +15,7 @@ use crate::proto;
 use crate::value::make_label_pairs;
 use crate::vec::{MetricVec, MetricVecBuilder};
 
-/// The default [`Histogram`](::Histogram) buckets. The default buckets are
+/// The default [`Histogram`] buckets. The default buckets are
 /// tailored to broadly measure the response time (in seconds) of a
 /// network service. Most likely, however, you will be required to define
 /// buckets customized to your use case.
@@ -63,7 +63,7 @@ fn check_and_adjust_buckets(mut buckets: Vec<f64>) -> Result<Vec<f64>> {
     Ok(buckets)
 }
 
-/// A struct that bundles the options for creating a [`Histogram`](::Histogram) metric. It is
+/// A struct that bundles the options for creating a [`Histogram`] metric. It is
 /// mandatory to set Name and Help to a non-empty string. All other fields are
 /// optional and can safely be left at their zero value.
 #[derive(Clone, Debug)]
@@ -80,7 +80,7 @@ pub struct HistogramOpts {
 }
 
 impl HistogramOpts {
-    /// Create a [`HistogramOpts`](::HistogramOpts) with the `name` and `help` arguments.
+    /// Create a [`HistogramOpts`] with the `name` and `help` arguments.
     pub fn new<S: Into<String>>(name: S, help: S) -> HistogramOpts {
         HistogramOpts {
             common_opts: Opts::new(name, help),
@@ -400,18 +400,18 @@ impl Drop for HistogramTimer {
     }
 }
 
-/// A [`Metric`](::core::Metric) counts individual observations from an event or sample stream in
-/// configurable buckets. Similar to a summary, it also provides a sum of
-/// observations and an observation count.
+/// A [`Metric`] counts individual observations from an event or sample stream
+/// in configurable buckets. Similar to a [`Summary`](crate::proto::Summary),
+/// it also provides a sum of observations and an observation count.
 ///
-/// On the Prometheus server, quantiles can be calculated from a [`Histogram`](::Histogram) using
+/// On the Prometheus server, quantiles can be calculated from a [`Histogram`] using
 /// the `histogram_quantile` function in the query language.
 ///
 /// Note that Histograms, in contrast to Summaries, can be aggregated with the
 /// Prometheus query language (see the documentation for detailed
 /// procedures). However, Histograms require the user to pre-define suitable
 /// buckets, and they are in general less accurate. The Observe method of a
-/// [`Histogram`](::Histogram) has a very low performance overhead in comparison with the Observe
+/// [`Histogram`] has a very low performance overhead in comparison with the Observe
 /// method of a Summary.
 #[derive(Clone, Debug)]
 pub struct Histogram {
@@ -419,7 +419,7 @@ pub struct Histogram {
 }
 
 impl Histogram {
-    /// `with_opts` creates a [`Histogram`](::Histogram) with the `opts` options.
+    /// `with_opts` creates a [`Histogram`] with the `opts` options.
     pub fn with_opts(opts: HistogramOpts) -> Result<Histogram> {
         Histogram::with_opts_and_label_values(&opts, &[])
     }
@@ -437,17 +437,17 @@ impl Histogram {
 }
 
 impl Histogram {
-    /// Add a single observation to the [`Histogram`](::Histogram).
+    /// Add a single observation to the [`Histogram`].
     pub fn observe(&self, v: f64) {
         self.core.observe(v)
     }
 
-    /// Return a [`HistogramTimer`](::HistogramTimer) to track a duration.
+    /// Return a [`HistogramTimer`] to track a duration.
     pub fn start_timer(&self) -> HistogramTimer {
         HistogramTimer::new(self.clone())
     }
 
-    /// Return a [`HistogramTimer`](::HistogramTimer) to track a duration.
+    /// Return a [`HistogramTimer`] to track a duration.
     /// It is faster but less precise.
     #[cfg(feature = "nightly")]
     pub fn start_coarse_timer(&self) -> HistogramTimer {
@@ -479,7 +479,7 @@ impl Histogram {
         res
     }
 
-    /// Return a [`LocalHistogram`](::local::LocalHistogram) for single thread usage.
+    /// Return a [`LocalHistogram`] for single thread usage.
     pub fn local(&self) -> LocalHistogram {
         LocalHistogram::new(self.clone())
     }
@@ -535,15 +535,15 @@ impl MetricVecBuilder for HistogramVecBuilder {
     }
 }
 
-/// A [`Collector`](::core::Collector) that bundles a set of Histograms that all share the
-/// same [`Desc`](::core::Desc), but have different values for their variable labels. This is used
+/// A [`Collector`] that bundles a set of Histograms that all share the
+/// same [`Desc`], but have different values for their variable labels. This is used
 /// if you want to count the same thing partitioned by various dimensions
 /// (e.g. HTTP request latencies, partitioned by status code and method).
 pub type HistogramVec = MetricVec<HistogramVecBuilder>;
 
 impl HistogramVec {
-    /// Create a new [`HistogramVec`](::HistogramVec) based on the provided
-    /// [`HistogramOpts`](::HistogramOpts) and partitioned by the given label names. At least
+    /// Create a new [`HistogramVec`] based on the provided
+    /// [`HistogramOpts`] and partitioned by the given label names. At least
     /// one label name must be provided.
     pub fn new(opts: HistogramOpts, label_names: &[&str]) -> Result<HistogramVec> {
         let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
@@ -564,7 +564,7 @@ impl HistogramVec {
 /// Create `count` buckets, each `width` wide, where the lowest
 /// bucket has an upper bound of `start`. The final +Inf bucket is not counted
 /// and not included in the returned slice. The returned slice is meant to be
-/// used for the Buckets field of [`HistogramOpts`](::HistogramOpts).
+/// used for the Buckets field of [`HistogramOpts`].
 ///
 /// The function returns an error if `count` is zero or `width` is zero or
 /// negative.
@@ -593,7 +593,7 @@ pub fn linear_buckets(start: f64, width: f64, count: usize) -> Result<Vec<f64>> 
 /// upper bound of `start` and each following bucket's upper bound is `factor`
 /// times the previous bucket's upper bound. The final +Inf bucket is not counted
 /// and not included in the returned slice. The returned slice is meant to be
-/// used for the Buckets field of [`HistogramOpts`](::HistogramOpts).
+/// used for the Buckets field of [`HistogramOpts`].
 ///
 /// The function returns an error if `count` is zero, if `start` is zero or
 /// negative, or if `factor` is less than or equal 1.
@@ -644,7 +644,7 @@ pub struct LocalHistogramCore {
     sum: f64,
 }
 
-/// An unsync [`Histogram`](::Histogram).
+/// An unsync [`Histogram`].
 #[derive(Debug)]
 pub struct LocalHistogram {
     core: RefCell<LocalHistogramCore>,
@@ -659,7 +659,7 @@ impl Clone for LocalHistogram {
     }
 }
 
-/// An unsync [`HistogramTimer`](::HistogramTimer).
+/// An unsync [`HistogramTimer`].
 #[must_use = "Timer should be kept in a variable otherwise it cannot observe duration"]
 #[derive(Debug)]
 pub struct LocalHistogramTimer {
@@ -810,7 +810,7 @@ impl LocalHistogram {
         }
     }
 
-    /// Add a single observation to the [`Histogram`](::Histogram).
+    /// Add a single observation to the [`Histogram`].
     pub fn observe(&self, v: f64) {
         self.core.borrow_mut().observe(v);
     }
@@ -857,7 +857,7 @@ impl LocalHistogram {
         self.core.borrow_mut().clear();
     }
 
-    /// Flush the local metrics to the [`Histogram`](::Histogram) metric.
+    /// Flush the local metrics to the [`Histogram`] metric.
     pub fn flush(&self) {
         self.core.borrow_mut().flush();
     }
@@ -886,7 +886,7 @@ impl Drop for LocalHistogram {
     }
 }
 
-/// An unsync [`HistogramVec`](::HistogramVec).
+/// An unsync [`HistogramVec`].
 #[derive(Debug)]
 pub struct LocalHistogramVec {
     vec: HistogramVec,
@@ -899,8 +899,8 @@ impl LocalHistogramVec {
         LocalHistogramVec { vec, local }
     }
 
-    /// Get a [`LocalHistogram`](::local::LocalHistogram) by label values.
-    /// See more [MetricVec::with_label_values](::core::MetricVec::with_label_values).
+    /// Get a [`LocalHistogram`] by label values.
+    /// See more [`MetricVec::with_label_values`].
     pub fn with_label_values<'a>(&'a mut self, vals: &[&str]) -> &'a LocalHistogram {
         let hash = self.vec.v.hash_label_values(vals).unwrap();
         let vec = &self.vec;
@@ -909,15 +909,15 @@ impl LocalHistogramVec {
             .or_insert_with(|| vec.with_label_values(vals).local())
     }
 
-    /// Remove a [`LocalHistogram`](::local::LocalHistogram) by label values.
-    /// See more [MetricVec::remove_label_values](::core::MetricVec::remove_label_values).
+    /// Remove a [`LocalHistogram`] by label values.
+    /// See more [`MetricVec::remove_label_values`].
     pub fn remove_label_values(&mut self, vals: &[&str]) -> Result<()> {
         let hash = self.vec.v.hash_label_values(vals)?;
         self.local.remove(&hash);
         self.vec.v.delete_label_values(vals)
     }
 
-    /// Flush the local metrics to the [`HistogramVec`](::HistogramVec) metric.
+    /// Flush the local metrics to the [`HistogramVec`] metric.
     pub fn flush(&self) {
         for h in self.local.values() {
             h.flush();

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -405,14 +405,18 @@ impl Drop for HistogramTimer {
 /// it also provides a sum of observations and an observation count.
 ///
 /// On the Prometheus server, quantiles can be calculated from a [`Histogram`] using
-/// the `histogram_quantile` function in the query language.
+/// the [`histogram_quantile`][1] function in the query language.
 ///
 /// Note that Histograms, in contrast to Summaries, can be aggregated with the
-/// Prometheus query language (see the documentation for detailed
-/// procedures). However, Histograms require the user to pre-define suitable
-/// buckets, and they are in general less accurate. The Observe method of a
-/// [`Histogram`] has a very low performance overhead in comparison with the Observe
-/// method of a Summary.
+/// Prometheus query language (see [the prometheus documentation][2] for
+/// detailed procedures). However, Histograms require the user to pre-define
+/// suitable buckets, (see [`linear_buckets`] and [`exponential_buckets`] for
+/// some helper provided here) and they are in general less accurate. The
+/// Observe method of a [`Histogram`] has a very low performance overhead in
+/// comparison with the Observe method of a Summary.
+///
+/// [1]: https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
+/// [2]: https://prometheus.io/docs/practices/histograms/
 #[derive(Clone, Debug)]
 pub struct Histogram {
     core: Arc<HistogramCore>,

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -878,7 +878,7 @@ impl LocalHistogram {
 }
 
 impl LocalMetric for LocalHistogram {
-    /// Flush the local metrics to the [`Histogram`](::Histogram) metric.
+    /// Flush the local metrics to the [`Histogram`] metric.
     fn flush(&self) {
         LocalHistogram::flush(self);
     }
@@ -930,7 +930,7 @@ impl LocalHistogramVec {
 }
 
 impl LocalMetric for LocalHistogramVec {
-    /// Flush the local metrics to the [`HistogramVec`](::HistogramVec) metric.
+    /// Flush the local metrics to the [`HistogramVec`] metric.
     fn flush(&self) {
         LocalHistogramVec::flush(self)
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,7 +36,7 @@ macro_rules! labels {
     };
 }
 
-/// Create an [`Opts`](::Opts).
+/// Create an [`Opts`].
 ///
 /// # Examples
 ///
@@ -82,7 +82,7 @@ macro_rules! opts {
     }
 }
 
-/// Create a [`HistogramOpts`](::HistogramOpts).
+/// Create a [`HistogramOpts`].
 ///
 /// # Examples
 ///
@@ -130,7 +130,7 @@ macro_rules! histogram_opts {
     }};
 }
 
-/// Create a [`Counter`](::Counter) and registers to default registry.
+/// Create a [`Counter`] and registers to default registry.
 ///
 /// # Examples
 ///
@@ -161,7 +161,7 @@ macro_rules! register_counter {
     }};
 }
 
-/// Create an [`IntCounter`](::IntCounter) and registers to default registry.
+/// Create an [`IntCounter`] and registers to default registry.
 ///
 /// View docs of `register_counter` for examples.
 #[macro_export(local_inner_macros)]
@@ -184,7 +184,7 @@ macro_rules! __register_counter_vec {
     }};
 }
 
-/// Create a [`CounterVec`](::CounterVec) and registers to default registry.
+/// Create a [`CounterVec`] and registers to default registry.
 ///
 /// # Examples
 ///
@@ -210,7 +210,7 @@ macro_rules! register_counter_vec {
     }};
 }
 
-/// Create an [`IntCounterVec`](::IntCounterVec) and registers to default registry.
+/// Create an [`IntCounterVec`] and registers to default registry.
 ///
 /// View docs of `register_counter_vec` for examples.
 #[macro_export(local_inner_macros)]
@@ -233,7 +233,7 @@ macro_rules! __register_gauge {
     }};
 }
 
-/// Create a [`Gauge`](::Gauge) and registers to default registry.
+/// Create a [`Gauge`] and registers to default registry.
 ///
 /// # Examples
 ///
@@ -259,7 +259,7 @@ macro_rules! register_gauge {
     }};
 }
 
-/// Create an [`IntGauge`](::IntGauge) and registers to default registry.
+/// Create an [`IntGauge`] and registers to default registry.
 ///
 /// View docs of `register_gauge` for examples.
 #[macro_export(local_inner_macros)]
@@ -282,7 +282,7 @@ macro_rules! __register_gauge_vec {
     }};
 }
 
-/// Create a [`GaugeVec`](::GaugeVec) and registers to default registry.
+/// Create a [`GaugeVec`] and registers to default registry.
 ///
 /// # Examples
 ///
@@ -308,7 +308,7 @@ macro_rules! register_gauge_vec {
     }};
 }
 
-/// Create an [`IntGaugeVec`](::IntGaugeVec) and registers to default registry.
+/// Create an [`IntGaugeVec`] and registers to default registry.
 ///
 /// View docs of `register_gauge_vec` for examples.
 #[macro_export(local_inner_macros)]
@@ -322,7 +322,7 @@ macro_rules! register_int_gauge_vec {
     }};
 }
 
-/// Create a [`Histogram`](::Histogram) and registers to default registry.
+/// Create a [`Histogram`] and registers to default registry.
 ///
 /// # Examples
 ///
@@ -358,7 +358,7 @@ macro_rules! register_histogram {
     }};
 }
 
-/// Create a [`HistogramVec`](::HistogramVec) and registers to default registry.
+/// Create a [`HistogramVec`] and registers to default registry.
 ///
 /// # Examples
 ///

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,23 +31,23 @@ pub trait LocalMetric {
     fn flush(&self);
 }
 
-/// A struct that bundles the options for creating most [`Metric`](::core::Metric) types.
+/// A struct that bundles the options for creating most [`Metric`] types.
 #[derive(Debug, Clone)]
 pub struct Opts {
     /// namespace, subsystem, and name are components of the fully-qualified
-    /// name of the [`Metric`](::core::Metric) (created by joining these components with
+    /// name of the [`Metric`] (created by joining these components with
     /// "_"). Only Name is mandatory, the others merely help structuring the
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
     pub namespace: String,
     /// namespace, subsystem, and name are components of the fully-qualified
-    /// name of the [`Metric`](::core::Metric) (created by joining these components with
+    /// name of the [`Metric`] (created by joining these components with
     /// "_"). Only Name is mandatory, the others merely help structuring the
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
     pub subsystem: String,
     /// namespace, subsystem, and name are components of the fully-qualified
-    /// name of the [`Metric`](::core::Metric) (created by joining these components with
+    /// name of the [`Metric`] (created by joining these components with
     /// "_"). Only Name is mandatory, the others merely help structuring the
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
@@ -69,10 +69,10 @@ pub struct Opts {
     /// serve only special purposes. One is for the special case where the
     /// value of a label does not change during the lifetime of a process,
     /// e.g. if the revision of the running binary is put into a
-    /// label. Another, more advanced purpose is if more than one [`Collector`](::core::Collector)
+    /// label. Another, more advanced purpose is if more than one [`Collector`]
     /// needs to collect Metrics with the same fully-qualified name. In that
     /// case, those Metrics must differ in the values of their
-    /// ConstLabels. See the [`Collector`](::core::Collector) examples.
+    /// ConstLabels. See the [`Collector`] examples.
     ///
     /// If the value of a label never changes (not even between binaries),
     /// that label most likely should not be a label at all (but part of the
@@ -170,10 +170,10 @@ impl PartialOrd for LabelPair {
 
 /// `build_fq_name` joins the given three name components by "_". Empty name
 /// components are ignored. If the name parameter itself is empty, an empty
-/// string is returned, no matter what. [`Metric`](::core::Metric) implementations included in this
+/// string is returned, no matter what. [`Metric`] implementations included in this
 /// library use this function internally to generate the fully-qualified metric
 /// name from the name component in their Opts. Users of the library will only
-/// need this function if they implement their own [`Metric`](::core::Metric) or instantiate a Desc
+/// need this function if they implement their own [`Metric`] or instantiate a Desc
 /// directly.
 fn build_fq_name(namespace: &str, subsystem: &str, name: &str) -> String {
     if name.is_empty() {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -264,23 +264,23 @@ impl Registry {
         Ok(reg)
     }
 
-    /// `register` registers a new [`Collector`](::core::Collector) to be included in metrics
+    /// `register` registers a new [`Collector`] to be included in metrics
     /// collection. It returns an error if the descriptors provided by the
-    /// [`Collector`](::core::Collector) are invalid or if they — in combination with descriptors of
+    /// [`Collector`] are invalid or if they — in combination with descriptors of
     /// already registered Collectors — do not fulfill the consistency and
-    /// uniqueness criteria described in the documentation of [`Desc`](::core::Desc).
+    /// uniqueness criteria described in the documentation of [`Desc`](crate::core::Desc).
     ///
-    /// If the provided [`Collector`](::core::Collector) is equal to a [`Collector`](::core::Collector) already registered
-    /// (which includes the case of re-registering the same [`Collector`](::core::Collector)), the
+    /// If the provided [`Collector`] is equal to a [`Collector`] already registered
+    /// (which includes the case of re-registering the same [`Collector`]), the
     /// AlreadyReg error returns.
     pub fn register(&self, c: Box<dyn Collector>) -> Result<()> {
         self.r.write().register(c)
     }
 
-    /// `unregister` unregisters the [`Collector`](::core::Collector) that equals the [`Collector`](::core::Collector) passed
+    /// `unregister` unregisters the [`Collector`] that equals the [`Collector`] passed
     /// in as an argument.  (Two Collectors are considered equal if their
     /// Describe method yields the same set of descriptors.) The function
-    /// returns error when the [`Collector`](::core::Collector) is not registered.
+    /// returns error when the [`Collector`] is not registered.
     pub fn unregister(&self, c: Box<dyn Collector>) -> Result<()> {
         self.r.write().unregister(c)
     }
@@ -326,19 +326,19 @@ pub fn default_registry() -> &'static Registry {
     &DEFAULT_REGISTRY
 }
 
-/// Registers a new [`Collector`](::core::Collector) to be included in metrics collection. It
-/// returns an error if the descriptors provided by the [`Collector`](::core::Collector) are invalid or
+/// Registers a new [`Collector`] to be included in metrics collection. It
+/// returns an error if the descriptors provided by the [`Collector`] are invalid or
 /// if they - in combination with descriptors of already registered Collectors -
-/// do not fulfill the consistency and uniqueness criteria described in the [`Desc`](::core::Desc)
-/// documentation.
+/// do not fulfill the consistency and uniqueness criteria described in the
+/// [`Desc`](crate::core::Desc) documentation.
 pub fn register(c: Box<dyn Collector>) -> Result<()> {
     DEFAULT_REGISTRY.register(c)
 }
 
-/// Unregisters the [`Collector`](::core::Collector) that equals the [`Collector`](::core::Collector) passed in as
+/// Unregisters the [`Collector`] that equals the [`Collector`] passed in as
 /// an argument. (Two Collectors are considered equal if their Describe method
 /// yields the same set of descriptors.) The function returns an error if a
-/// [`Collector`](::core::Collector) was not registered.
+/// [`Collector`] was not registered.
 pub fn unregister(c: Box<dyn Collector>) -> Result<()> {
     DEFAULT_REGISTRY.unregister(c)
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,7 +7,7 @@ use crate::errors::{Error, Result};
 use crate::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
 
 /// `ValueType` is an enumeration of metric types that represent a simple value
-/// for [`Counter`](::Counter) and [`Gauge`](::Gauge).
+/// for [`Counter`] and [`Gauge`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ValueType {
     Counter,
@@ -24,10 +24,10 @@ impl ValueType {
     }
 }
 
-/// A generic metric for [`Counter`](::Counter) and [`Gauge`](::Gauge).
+/// A generic metric for [`Counter`] and [`Gauge`].
 /// Its effective type is determined by `ValueType`. This is a low-level
 /// building block used by the library to back the implementations of
-/// [`Counter`](::Counter) and [`Gauge`](::Gauge).
+/// [`Counter`] and [`Gauge`].
 #[derive(Debug)]
 pub struct Value<P: Atomic> {
     pub desc: Desc,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -20,7 +20,7 @@ pub trait MetricVecBuilder: Send + Sync + Clone {
     /// The associated describer.
     type P: Describer + Sync + Send + Clone;
 
-    /// `build` builds a [`Metric`](::core::Metric) with option and corresponding label names.
+    /// `build` builds a [`Metric`] with option and corresponding label names.
     fn build(&self, _: &Self::P, _: &[&str]) -> Result<Self::M>;
 }
 
@@ -166,11 +166,11 @@ impl<T: MetricVecBuilder> MetricVecCore<T> {
     }
 }
 
-/// A [`Collector`](::core::Collector) to bundle metrics of the same name that
+/// A [`Collector`] to bundle metrics of the same name that
 /// differ in their label values. It is usually not used directly but as a
 /// building block for implementations of vectors of a given metric
-/// type. [`GaugeVec`](::GaugeVec) and [`CounterVec`](::CounterVec) are examples already
-/// provided in this package.
+/// type. [`GaugeVec`](crate::GaugeVec) and [`CounterVec`](crate::CounterVec)
+/// are examples already provided in this package.
 #[derive(Clone)]
 pub struct MetricVec<T: MetricVecBuilder> {
     pub(crate) v: Arc<MetricVecCore<T>>,
@@ -198,19 +198,19 @@ impl<T: MetricVecBuilder> MetricVec<T> {
         Ok(MetricVec { v: Arc::new(v) })
     }
 
-    /// `get_metric_with_label_values` returns the [`Metric`](::core::Metric) for the given slice
+    /// `get_metric_with_label_values` returns the [`Metric`] for the given slice
     /// of label values (same order as the VariableLabels in Desc). If that combination of
-    /// label values is accessed for the first time, a new [`Metric`](::core::Metric) is created.
+    /// label values is accessed for the first time, a new [`Metric`] is created.
     ///
-    /// It is possible to call this method without using the returned [`Metric`](::core::Metric)
-    /// to only create the new [`Metric`](::core::Metric) but leave it at its start value (e.g. a
-    /// [`Histogram`](::Histogram) without any observations).
+    /// It is possible to call this method without using the returned [`Metric`]
+    /// to only create the new [`Metric`] but leave it at its start value (e.g. a
+    /// [`Histogram`](crate::Histogram) without any observations).
     ///
-    /// Keeping the [`Metric`](::core::Metric) for later use is possible (and should be considered
+    /// Keeping the [`Metric`] for later use is possible (and should be considered
     /// if performance is critical), but keep in mind that Reset, DeleteLabelValues and Delete can
-    /// be used to delete the [`Metric`](::core::Metric) from the MetricVec. In that case, the
-    /// [`Metric`](::core::Metric) will still exist, but it will not be exported anymore, even if a
-    /// [`Metric`](::core::Metric) with the same label values is created later. See also the
+    /// be used to delete the [`Metric`] from the MetricVec. In that case, the
+    /// [`Metric`] will still exist, but it will not be exported anymore, even if a
+    /// [`Metric`] with the same label values is created later. See also the
     /// CounterVec example.
     ///
     /// An error is returned if the number of label values is not the same as the
@@ -225,11 +225,11 @@ impl<T: MetricVecBuilder> MetricVec<T> {
         self.v.get_metric_with_label_values(vals)
     }
 
-    /// `get_metric_with` returns the [`Metric`](::core::Metric) for the given Labels map (the
+    /// `get_metric_with` returns the [`Metric`] for the given Labels map (the
     /// label names must match those of the VariableLabels in Desc). If that label map is
-    /// accessed for the first time, a new [`Metric`](::core::Metric) is created. Implications of
-    /// creating a [`Metric`](::core::Metric) without using it and keeping the
-    /// [`Metric`](::core::Metric) for later use are the same as for GetMetricWithLabelValues.
+    /// accessed for the first time, a new [`Metric`] is created. Implications of
+    /// creating a [`Metric`] without using it and keeping the
+    /// [`Metric`] for later use are the same as for GetMetricWithLabelValues.
     ///
     /// An error is returned if the number and names of the Labels are inconsistent
     /// with those of the VariableLabels in Desc.


### PR DESCRIPTION
Wherever possible, use the default linking style of looking names up in the
enclosing namespace without adding an explicit link, but sometimes we need to
add the link target via parens, in those cases correct from `::Name` to
`crate::Name`.
