### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8.0
+
+- Add: Reset Counters (#261)
+
+- Add: Discard Histogram timers (#257)
+
+- Add: `observe_closure_duration` for better observing closure duration for local histogram (#296)
+
+- Fix a bug that global labels are not handled correctly (#269)
+
+- Improve linear bucket accuracy by avoiding accumulating error (#276)
+
+- Internal change: Use [thiserror](https://docs.rs/thiserror) to generate the error structure (#285)
+
+- Internal change: Switch from procinfo to [procfs](https://docs.rs/procfs) (#290)
+
+- Internal change: Update to newer dependencies
+
 ## 0.7.0
 
 - Provide immutable interface for local counters.

--- a/README.md
+++ b/README.md
@@ -10,35 +10,24 @@ The main Structures and APIs are ported from [Go client](https://github.com/prom
 
 ## Usage
 
-+ Add this to your `Cargo.toml`:
+- Add dependency to your `Cargo.toml`:
 
-    ```toml
-    [dependencies]
-    prometheus = "0.7"
-    ```
+  ```toml
+  prometheus = "0.8"
+  ```
 
-+ Add this to your crate in `lib.rs`:
+- Optional: Better performance for Rust nightly.
 
-    ```rust
-    extern crate prometheus;
-    ```
-
-+ Or enable nightly feature for better performance.
-
-    ```toml
-    [dependencies.prometheus]
-    git = "https://github.com/pingcap/rust-prometheus.git"
-    features = ["nightly"]
-    ```
+  ```toml
+  prometheus = { version = "0.8", features = ["nightly"] }
+  ```
 
 ### Note
 
 The crate has a pre-generated protobuf binding file for `protobuf` v2.0, if you need use the latest version of `protobuf`, you can generate the binding file on building with the `gen` feature.
 
 ```toml
-[dependencies.prometheus]
-git = "https://github.com/pingcap/rust-prometheus.git"
-features = ["gen"]
+prometheus = { version = "0.8", features = ["gen"] }
 ```
 
 ## Example
@@ -79,7 +68,8 @@ See [static-metric](./static-metric) directory for details.
 
 ## Thanks
 
-+ [brian-brazil](https://github.com/brian-brazil)
-+ [ccmtaylor](https://github.com/ccmtaylor)
-+ [kamalmarhubi](https://github.com/kamalmarhubi)
-+ [lucab](https://github.com/lucab)
+- [brian-brazil](https://github.com/brian-brazil)
+- [ccmtaylor](https://github.com/ccmtaylor)
+- [kamalmarhubi](https://github.com/kamalmarhubi)
+- [lucab](https://github.com/lucab)
+- [koushiro](https://github.com/koushiro)


### PR DESCRIPTION
This PR modifies necessary documentation to use the verson 0.8.0. We will use this commit to publish the version.

Note that `Cargo.toml` was already changed to 0.8.0.

Signed-off-by: Breezewish <me@breeswish.org>