### PR TITLE
Replace spin with parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ lazy_static = "1.4"
 libc = { version = "0.2", optional = true }
 protobuf = { version = "2.0", optional = true }
 reqwest = { version = "0.10", features = ["blocking"], optional = true }
-spin = "0.5.2"
 thiserror = "1.0"
+parking_lot = "0.10.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.7", optional = true, default-features = false }

--- a/src/auto_flush.rs
+++ b/src/auto_flush.rs
@@ -3,7 +3,7 @@ use crate::counter::{CounterWithValueType, GenericLocalCounter};
 use crate::histogram::{Instant, LocalHistogram};
 use crate::metrics::MayFlush;
 use crate::timer;
-use spin::Mutex;
+use parking_lot::Mutex;
 use std::thread::LocalKey;
 
 /// Delegator for auto flush-able local counter

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,7 +6,7 @@ use std::collections::hash_map::Entry as HEntry;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
-use spin::RwLock;
+use parking_lot::RwLock;
 
 use crate::errors::{Error, Result};
 use crate::metrics::Collector;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -6,7 +6,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use fnv::FnvHasher;
-use spin::RwLock;
+use parking_lot::RwLock;
 
 use crate::desc::{Desc, Describer};
 use crate::errors::{Error, Result};


### PR DESCRIPTION
Benchmarks:

```
 name                                              spin ns/iter  parking_lot ns/iter  diff ns/iter   diff %  speedup 
 bench_atomic_f64                                  4             4                               0    0.00%   x 1.00 
 bench_atomic_i64                                  4             4                               0    0.00%   x 1.00 
 bench_counter_no_labels                           4             4                               0    0.00%   x 1.00 
 bench_counter_no_labels_concurrent_nop            4             4                               0    0.00%   x 1.00 
 bench_counter_no_labels_concurrent_write          43            128                            85  197.67%   x 0.34 
 bench_counter_with_label_values                   35            36                              1    2.86%   x 0.97 
 bench_counter_with_label_values_concurrent_write  684           361                          -323  -47.22%   x 1.89 
 bench_counter_with_mapped_labels                  183           175                            -8   -4.37%   x 1.05 
 bench_counter_with_prepared_mapped_labels         93            92                             -1   -1.08%   x 1.01 
 bench_gauge_no_labels                             4             4                               0    0.00%   x 1.00 
 bench_gauge_with_label_values                     35            36                              1    2.86%   x 0.97 
 bench_histogram_local                             5             6                               1   20.00%   x 0.83 
 bench_histogram_no_labels                         13            13                              0    0.00%   x 1.00 
 bench_histogram_timer                             92            91                             -1   -1.09%   x 1.01 
 bench_histogram_with_label_values                 46            48                              2    4.35%   x 0.96 
 bench_int_counter_no_labels                       4             4                               0    0.00%   x 1.00 
 bench_int_counter_no_labels_concurrent_write      44            42                             -2   -4.55%   x 1.05 
 bench_int_gauge_no_labels                         4             4                               0    0.00%   x 1.00 
 bench_local_histogram_timer                       125           123                            -2   -1.60%   x 1.02 
```

I also tried bumping the number of threads in the concurrent counter benchmarks
up to 20 to match my cpu, giving much closer, but more variable, results for
those

```
 name                                              spin-20 ns/iter  parking_lot-20 ns/iter  diff ns/iter   diff %  speedup 
 bench_counter_no_labels_concurrent_nop            4                4                                  0    0.00%   x 1.00 
 bench_counter_no_labels_concurrent_write          369              388                               19    5.15%   x 0.95 
 bench_counter_with_label_values_concurrent_write  1,775            1,995                            220   12.39%   x 0.89 
 bench_int_counter_no_labels_concurrent_write      144              144                                0    0.00%   x 1.00 
```

<details>
<summary>full benchmark results</summary>

`spin`:

```
test bench_atomic_f64                                 ... bench:           4 ns/iter (+/- 0)
test bench_atomic_i64                                 ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels                          ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels_concurrent_nop           ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels_concurrent_write         ... bench:          43 ns/iter (+/- 1)
test bench_counter_with_label_values                  ... bench:          35 ns/iter (+/- 0)
test bench_counter_with_label_values_concurrent_write ... bench:         684 ns/iter (+/- 10)
test bench_counter_with_mapped_labels                 ... bench:         183 ns/iter (+/- 3)
test bench_counter_with_prepared_mapped_labels        ... bench:          93 ns/iter (+/- 2)
test bench_int_counter_no_labels                      ... bench:           4 ns/iter (+/- 0)
test bench_int_counter_no_labels_concurrent_write     ... bench:          44 ns/iter (+/- 0)
test bench_gauge_no_labels                            ... bench:           4 ns/iter (+/- 0)
test bench_gauge_with_label_values                    ... bench:          35 ns/iter (+/- 0)
test bench_int_gauge_no_labels                        ... bench:           4 ns/iter (+/- 0)
test bench_histogram_local                            ... bench:           5 ns/iter (+/- 0)
test bench_histogram_no_labels                        ... bench:          13 ns/iter (+/- 0)
test bench_histogram_timer                            ... bench:          92 ns/iter (+/- 2)
test bench_histogram_with_label_values                ... bench:          46 ns/iter (+/- 0)
test bench_local_histogram_timer                      ... bench:         125 ns/iter (+/- 1)
```

`parking_lot`:

```
test bench_atomic_f64                                 ... bench:           4 ns/iter (+/- 0)
test bench_atomic_i64                                 ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels                          ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels_concurrent_nop           ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels_concurrent_write         ... bench:         128 ns/iter (+/- 16)
test bench_counter_with_label_values                  ... bench:          36 ns/iter (+/- 0)
test bench_counter_with_label_values_concurrent_write ... bench:         361 ns/iter (+/- 5)
test bench_counter_with_mapped_labels                 ... bench:         175 ns/iter (+/- 3)
test bench_counter_with_prepared_mapped_labels        ... bench:          92 ns/iter (+/- 1)
test bench_int_counter_no_labels                      ... bench:           4 ns/iter (+/- 0)
test bench_int_counter_no_labels_concurrent_write     ... bench:          42 ns/iter (+/- 66)
test bench_gauge_no_labels                            ... bench:           4 ns/iter (+/- 0)
test bench_gauge_with_label_values                    ... bench:          36 ns/iter (+/- 0)
test bench_int_gauge_no_labels                        ... bench:           4 ns/iter (+/- 0)
test bench_histogram_local                            ... bench:           6 ns/iter (+/- 0)
test bench_histogram_no_labels                        ... bench:          13 ns/iter (+/- 0)
test bench_histogram_timer                            ... bench:          91 ns/iter (+/- 1)
test bench_histogram_with_label_values                ... bench:          48 ns/iter (+/- 1)
test bench_local_histogram_timer                      ... bench:         123 ns/iter (+/- 2)
```

`spin`, 20 threads:

```
test bench_counter_no_labels_concurrent_nop           ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels_concurrent_write         ... bench:         369 ns/iter (+/- 330)
test bench_counter_with_label_values_concurrent_write ... bench:       1,775 ns/iter (+/- 114)
test bench_int_counter_no_labels_concurrent_write     ... bench:         144 ns/iter (+/- 55)
```

`parking_lot`, 20 threads:

```
test bench_counter_no_labels_concurrent_nop           ... bench:           4 ns/iter (+/- 0)
test bench_counter_no_labels_concurrent_write         ... bench:         388 ns/iter (+/- 285)
test bench_counter_with_label_values_concurrent_write ... bench:       1,995 ns/iter (+/- 1,134)
test bench_int_counter_no_labels_concurrent_write     ... bench:         144 ns/iter (+/- 57)
```

</details>

fixes #305
