### PR TITLE
Add summary metric type to the encode function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add: Implement `encode` function for summary type metrics. 
+
 ## 0.8.0
 
 - Add: Reset Counters (#261)


### PR DESCRIPTION
This adds code for handling summary metrics when calling the "encode" function to write quantile, count and sum metrics using the functions implemented on `Summary`. 