### PR TITLE
Use different generic parameters where needed

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -37,7 +37,7 @@ impl<P: Atomic> Clone for GenericCounter<P> {
 
 impl<P: Atomic> GenericCounter<P> {
     /// Create a [`GenericCounter`] with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
+    pub fn new<S1: Into<String>, S2: Into<String>>(name: S1, help: S2) -> Result<Self> {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -36,7 +36,7 @@ impl<P: Atomic> Clone for GenericGauge<P> {
 
 impl<P: Atomic> GenericGauge<P> {
     /// Create a [`GenericGauge`] with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
+    pub fn new<S1: Into<String>, S2: Into<String>>(name: S1, help: S2) -> Result<Self> {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -81,7 +81,7 @@ pub struct HistogramOpts {
 
 impl HistogramOpts {
     /// Create a [`HistogramOpts`] with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> HistogramOpts {
+    pub fn new<S1: Into<String>, S2: Into<String>>(name: S1, help: S2) -> HistogramOpts {
         HistogramOpts {
             common_opts: Opts::new(name, help),
             buckets: Vec::from(DEFAULT_BUCKETS as &'static [f64]),
@@ -107,7 +107,7 @@ impl HistogramOpts {
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
+    pub fn const_label<S1: Into<String>, S2: Into<String>>(mut self, name: S1, value: S2) -> Self {
         self.common_opts = self.common_opts.const_label(name, value);
         self
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -111,7 +111,7 @@ pub struct Opts {
 
 impl Opts {
     /// `new` creates the Opts with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Opts {
+    pub fn new<S1: Into<String>, S2: Into<String>>(name: S1, help: S2) -> Opts {
         Opts {
             namespace: "".to_owned(),
             subsystem: "".to_owned(),
@@ -141,7 +141,7 @@ impl Opts {
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
+    pub fn const_label<S1: Into<String>, S2: Into<String>>(mut self, name: S1, value: S2) -> Self {
         self.const_labels.insert(name.into(), value.into());
         self
     }
@@ -257,5 +257,10 @@ mod tests {
         for (namespace, subsystem, name, res) in tbl {
             assert_eq!(&build_fq_name(namespace, subsystem, name), res);
         }
+    }
+
+    #[test]
+    fn test_different_generic_types() {
+        Opts::new(format!("{}_{}", "string", "label"), "&str_label");
     }
 }


### PR DESCRIPTION
Otherwise you force same type on both arguments which is not ideal