### PR TITLE
src/value: Have make_label_pairs error instead of panic

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -1235,7 +1235,7 @@ mod tests {
                 "Used as an example",
                 vec![0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 5.0]
             )
-                .variable_label("example_variable"),
+            .variable_label("example_variable"),
         );
 
         if let Err(Error::InconsistentCardinality { expect, got }) = hist {

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -173,7 +173,8 @@ impl HistogramCore {
         for pair in &desc.const_label_pairs {
             check_bucket_label(pair.get_name())?;
         }
-        let pairs = make_label_pairs(&desc, label_values);
+
+        let label_pairs = make_label_pairs(&desc, label_values)?;
 
         let buckets = check_and_adjust_buckets(opts.buckets.clone())?;
 
@@ -184,7 +185,7 @@ impl HistogramCore {
 
         Ok(HistogramCore {
             desc,
-            label_pairs: pairs,
+            label_pairs,
             sum: AtomicF64::new(0.0),
             count: AtomicU64::new(0),
             upper_bounds: buckets,
@@ -1223,6 +1224,25 @@ mod tests {
             local_vec.with_label_values(&["v1", "v2"]).observe(2.0);
             drop(local_vec);
             check(1, 2.0);
+        }
+    }
+
+    #[test]
+    fn test_error_on_inconsistent_label_cardinality() {
+        let hist = Histogram::with_opts(
+            histogram_opts!(
+                "example_histogram",
+                "Used as an example",
+                vec![0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 5.0]
+            )
+                .variable_label("example_variable"),
+        );
+
+        if let Err(Error::InconsistentCardinality { expect, got }) = hist {
+            assert_eq!(1, expect);
+            assert_eq!(0, got);
+        } else {
+            panic!("Expected InconsistentCardinality error.")
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -44,14 +44,7 @@ impl<P: Atomic> Value<P> {
         label_values: &[&str],
     ) -> Result<Self> {
         let desc = describer.describe()?;
-        if desc.variable_labels.len() != label_values.len() {
-            return Err(Error::InconsistentCardinality {
-                expect: desc.variable_labels.len(),
-                got: label_values.len(),
-            });
-        }
-
-        let label_pairs = make_label_pairs(&desc, label_values);
+        let label_pairs = make_label_pairs(&desc, label_values)?;
 
         Ok(Self {
             desc,
@@ -122,14 +115,21 @@ impl<P: Atomic> Value<P> {
     }
 }
 
-pub fn make_label_pairs(desc: &Desc, label_values: &[&str]) -> Vec<LabelPair> {
+pub fn make_label_pairs(desc: &Desc, label_values: &[&str]) -> Result<Vec<LabelPair>> {
+    if desc.variable_labels.len() != label_values.len() {
+        return Err(Error::InconsistentCardinality {
+            expect: desc.variable_labels.len(),
+            got: label_values.len(),
+        });
+    }
+
     let total_len = desc.variable_labels.len() + desc.const_label_pairs.len();
     if total_len == 0 {
-        return vec![];
+        return Ok(vec![]);
     }
 
     if desc.variable_labels.is_empty() {
-        return desc.const_label_pairs.clone();
+        return Ok(desc.const_label_pairs.clone());
     }
 
     let mut label_pairs = Vec::with_capacity(total_len);
@@ -144,5 +144,5 @@ pub fn make_label_pairs(desc: &Desc, label_values: &[&str]) -> Vec<LabelPair> {
         label_pairs.push(label_pair.clone());
     }
     label_pairs.sort();
-    label_pairs
+    Ok(label_pairs)
 }


### PR DESCRIPTION
`make_label_pairs` expects `desc.variable_labels.len()` to equal the provided
`label_values.len()`. Instead of panicing on out of range indexing
return an error.

Fixes https://github.com/tikv/rust-prometheus/issues/306.