### PR TITLE
src/encoder/text: Optimize metric formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ fnv = "1.0"
 lazy_static = "1.4"
 libc = { version = "0.2", optional = true }
 protobuf = { version = "2.0", optional = true }
+regex = "1.3"
 reqwest = { version = "0.10", features = ["blocking"], optional = true }
 thiserror = "1.0"
 parking_lot = "0.10.2"

--- a/benches/text_encoder.rs
+++ b/benches/text_encoder.rs
@@ -1,0 +1,79 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(test)]
+
+extern crate test;
+
+use prometheus::{CounterVec, Encoder, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder};
+use test::Bencher;
+
+#[bench]
+fn bench_text_encoder_without_escaping(b: &mut Bencher) {
+    let registry = registry_with_test_metrics(false);
+    run_text_encoder(registry, b)
+}
+
+#[bench]
+fn bench_text_encoder_with_escaping(b: &mut Bencher) {
+    let registry = registry_with_test_metrics(true);
+    run_text_encoder(registry, b)
+}
+
+fn registry_with_test_metrics(with_escaping: bool) -> Registry {
+    let registry = Registry::new();
+
+    for i in 0..100 {
+        let counter = CounterVec::new(
+            Opts::new(
+                format!("benchmark_counter_{}", i),
+                "A counter to benchmark it.",
+            ),
+            &["one", "two", "three"],
+        )
+        .unwrap();
+        registry.register(Box::new(counter.clone())).unwrap();
+
+        let histogram = HistogramVec::new(
+            HistogramOpts::new(
+                format!("benchmark_histogram_{}", i),
+                "A histogram to benchmark it.",
+            ),
+            &["one", "two", "three"],
+        )
+        .unwrap();
+        registry.register(Box::new(histogram.clone())).unwrap();
+
+        for j in 0..100 {
+            let j_string = j.to_string();
+            let label_values = if with_escaping {
+                ["ei\\ns\n", "zw\"e\"i", &j_string]
+            } else {
+                ["eins", "zwei", &j_string]
+            };
+
+            counter.with_label_values(&label_values).inc();
+            histogram.with_label_values(&label_values).observe(j.into());
+        }
+    }
+
+    registry
+}
+
+fn run_text_encoder(registry: Registry, b: &mut Bencher) {
+    let mut buffer = vec![];
+    let encoder = TextEncoder::new();
+    let metric_families = registry.gather();
+
+    b.iter(|| encoder.encode(&metric_families, &mut buffer).unwrap());
+}

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -32,23 +32,33 @@ impl Encoder for TextEncoder {
             // Fail-fast checks.
             check_metric_family(mf)?;
 
+            // Write `# HELP` header.
             let name = mf.get_name();
             let help = mf.get_help();
             if !help.is_empty() {
-                writeln!(writer, "# HELP {} {}", name, escape_string(help, false))?;
+                writer.write_all(b"# HELP ")?;
+                writer.write_all(name.as_bytes())?;
+                writer.write_all(b" ")?;
+                writer.write_all(escape_string(help, false).as_bytes())?;
+                writer.write_all(b"\n")?;
             }
 
+            // Write `# TYPE` header.
             let metric_type = mf.get_field_type();
             let lowercase_type = format!("{:?}", metric_type).to_lowercase();
-            writeln!(writer, "# TYPE {} {}", name, lowercase_type)?;
+            writer.write_all(b"# TYPE ")?;
+            writer.write_all(name.as_bytes())?;
+            writer.write_all(b" ")?;
+            writer.write_all(lowercase_type.as_bytes())?;
+            writer.write_all(b"\n")?;
 
             for m in mf.get_metric() {
                 match metric_type {
                     MetricType::COUNTER => {
-                        write_sample(name, m, "", "", m.get_counter().get_value(), writer)?;
+                        write_sample(writer, name, None, m, None, m.get_counter().get_value())?;
                     }
                     MetricType::GAUGE => {
-                        write_sample(name, m, "", "", m.get_gauge().get_value(), writer)?;
+                        write_sample(writer, name, None, m, None, m.get_gauge().get_value())?;
                     }
                     MetricType::HISTOGRAM => {
                         let h = m.get_histogram();
@@ -57,12 +67,12 @@ impl Encoder for TextEncoder {
                         for b in h.get_bucket() {
                             let upper_bound = b.get_upper_bound();
                             write_sample(
-                                &format!("{}_bucket", name),
-                                m,
-                                BUCKET_LABEL,
-                                &format!("{}", upper_bound),
-                                b.get_cumulative_count() as f64,
                                 writer,
+                                name,
+                                Some("_bucket"),
+                                m,
+                                Some((BUCKET_LABEL, &upper_bound.to_string())),
+                                b.get_cumulative_count() as f64,
                             )?;
                             if upper_bound.is_sign_positive() && upper_bound.is_infinite() {
                                 inf_seen = true;
@@ -70,31 +80,24 @@ impl Encoder for TextEncoder {
                         }
                         if !inf_seen {
                             write_sample(
-                                &format!("{}_bucket", name),
-                                m,
-                                BUCKET_LABEL,
-                                POSITIVE_INF,
-                                h.get_sample_count() as f64,
                                 writer,
+                                name,
+                                Some("_bucket"),
+                                m,
+                                Some((BUCKET_LABEL, POSITIVE_INF)),
+                                h.get_sample_count() as f64,
                             )?;
                         }
 
-                        write_sample(
-                            &format!("{}_sum", name),
-                            m,
-                            "",
-                            "",
-                            h.get_sample_sum(),
-                            writer,
-                        )?;
+                        write_sample(writer, name, Some("_sum"), m, None, h.get_sample_sum())?;
 
                         write_sample(
-                            &format!("{}_count", name),
-                            m,
-                            "",
-                            "",
-                            h.get_sample_count() as f64,
                             writer,
+                            name,
+                            Some("_count"),
+                            m,
+                            None,
+                            h.get_sample_count() as f64,
                         )?;
                     }
                     MetricType::SUMMARY => {
@@ -102,31 +105,24 @@ impl Encoder for TextEncoder {
 
                         for q in s.get_quantile() {
                             write_sample(
-                                name,
-                                m,
-                                QUANTILE,
-                                &format!("{}", q.get_quantile()),
-                                q.get_value(),
                                 writer,
+                                name,
+                                None,
+                                m,
+                                Some((QUANTILE, &q.get_quantile().to_string())),
+                                q.get_value(),
                             )?;
                         }
 
-                        write_sample(
-                            &format!("{}_sum", name),
-                            m,
-                            "",
-                            "",
-                            s.get_sample_sum(),
-                            writer,
-                        )?;
+                        write_sample(writer, name, Some("_sum"), m, None, s.get_sample_sum())?;
 
                         write_sample(
-                            &format!("{}_count", name),
-                            m,
-                            "",
-                            "",
-                            s.get_sample_count() as f64,
                             writer,
+                            name,
+                            Some("_count"),
+                            m,
+                            None,
+                            s.get_sample_count() as f64,
                         )?;
                     }
                     MetricType::UNTYPED => {
@@ -149,27 +145,27 @@ impl Encoder for TextEncoder {
 /// name and value (use empty strings if not required), and the value.
 /// The function returns the number of bytes written and any error encountered.
 fn write_sample(
-    name: &str,
-    mc: &proto::Metric,
-    additional_label_name: &str,
-    additional_label_value: &str,
-    value: f64,
     writer: &mut dyn Write,
+    name: &str,
+    name_postfix: Option<&str>,
+    mc: &proto::Metric,
+    additional_label: Option<(&str, &str)>,
+    value: f64,
 ) -> Result<()> {
     writer.write_all(name.as_bytes())?;
+    if let Some(postfix) = name_postfix {
+        writer.write_all(postfix.as_bytes())?;
+    }
 
-    label_pairs_to_text(
-        mc.get_label(),
-        additional_label_name,
-        additional_label_value,
-        writer,
-    )?;
+    label_pairs_to_text(mc.get_label(), additional_label, writer)?;
 
-    write!(writer, " {}", value)?;
+    writer.write_all(b" ")?;
+    writer.write_all(value.to_string().as_bytes())?;
 
     let timestamp = mc.get_timestamp_ms();
     if timestamp != 0 {
-        write!(writer, " {}", timestamp)?;
+        writer.write_all(b" ")?;
+        writer.write_all(timestamp.to_string().as_bytes())?;
     }
 
     writer.write_all(b"\n")?;
@@ -186,35 +182,30 @@ fn write_sample(
 /// bytes written and any error encountered.
 fn label_pairs_to_text(
     pairs: &[proto::LabelPair],
-    additional_label_name: &str,
-    additional_label_value: &str,
+    additional_label: Option<(&str, &str)>,
     writer: &mut dyn Write,
 ) -> Result<()> {
-    if pairs.is_empty() && additional_label_name.is_empty() {
+    if pairs.is_empty() && additional_label.is_none() {
         return Ok(());
     }
 
-    let mut separator = "{";
+    let mut separator = b"{";
     for lp in pairs {
-        write!(
-            writer,
-            "{}{}=\"{}\"",
-            separator,
-            lp.get_name(),
-            escape_string(lp.get_value(), true)
-        )?;
+        writer.write_all(separator)?;
+        writer.write_all(lp.get_name().as_bytes())?;
+        writer.write_all(b"=\"")?;
+        writer.write_all(escape_string(lp.get_value(), true).as_bytes())?;
+        writer.write_all(b"\"")?;
 
-        separator = ",";
+        separator = b",";
     }
 
-    if !additional_label_name.is_empty() {
-        write!(
-            writer,
-            "{}{}=\"{}\"",
-            separator,
-            additional_label_name,
-            escape_string(additional_label_value, true)
-        )?;
+    if let Some((name, value)) = additional_label {
+        writer.write_all(separator)?;
+        writer.write_all(name.as_bytes())?;
+        writer.write_all(b"=\"")?;
+        writer.write_all(escape_string(value, true).as_bytes())?;
+        writer.write_all(b"\"")?;
     }
 
     writer.write_all(b"}")?;

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -255,6 +255,8 @@ fn escape_string(v: &str, include_double_quote: bool) -> Cow<'_, str> {
                 }
             }
         }
+
+        escaped.shrink_to_fit();
         escaped.into()
     } else {
         // The input string does not contain any characters that would need to


### PR DESCRIPTION
This pull request addresses the low-hanging-fruits within `src/encoder/text.rs` with the following commits:

- src/benches&src/bin: Add basic text encoder benchmark

- src/encoder/text: Use `write_all` instead of `write_fmt`

  Instead of going through `write!` which calls `write_fmt` use `write_all` directly skipping the additional formatting overhead.

- src/encoder/text: Use regex crate to determine if escaping is needed

  Within `escape_string` instead of always allocating a new String and iterating through each character one-by-one, first check whether the input string needs any escaping, if not, return without any allocation. If it does need escaping, start from the first occurence.

Benchmark results on a `Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz`:

```bash
$ cargo benchcmp master optimized
 name                                 master ns/iter  optimized ns/iter  diff ns/iter   diff %  speedup 
 bench_text_encoder_with_escaping     131,884,199     105,675,740         -26,208,459  -19.87%   x 1.25 
 bench_text_encoder_without_escaping  117,592,719     73,070,167          -44,522,552  -37.86%   x 1.61
```

CPU flamegraph before:
![master](https://user-images.githubusercontent.com/7047859/82989709-65198380-9ffb-11ea-94de-8de0b52dc48f.png)


CPU flamegraph after:
![optimized](https://user-images.githubusercontent.com/7047859/82989771-7a8ead80-9ffb-11ea-8603-8ee34aaee64d.png)

Memory allocation flamegraph before:
![image](https://user-images.githubusercontent.com/7047859/82989870-9b570300-9ffb-11ea-8663-d7af754c3279.png)

Memory allocation flamegraph after:
![image](https://user-images.githubusercontent.com/7047859/82989918-ad38a600-9ffb-11ea-9d8a-1e02e7e13205.png)






