### PR TITLE
*: Rework README and src/lib documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ This library supports four features:
 
 - `nightly`: Enable nightly only features.
 
-- `push`: Enable push support.
-
 - `process`: For collecting process info.
 
 - `push`: Enable push support.
@@ -34,7 +32,9 @@ This library supports four features:
 
 ### Static Metric
 
-Static metric helps you make metric vectors faster.
+When using a `MetricVec` with label values known at compile time
+prometheus-static-metric reduces the overhead of retrieving the concrete
+`Metric` from a `MetricVec`.
 
 See [static-metric](./static-metric) directory for details.
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,40 @@
 [![Build Status](https://travis-ci.org/tikv/rust-prometheus.svg?branch=master)](https://travis-ci.org/pingcap/rust-prometheus)
 [![docs.rs](https://docs.rs/prometheus/badge.svg)](https://docs.rs/prometheus)
 [![crates.io](http://meritbadge.herokuapp.com/prometheus)](https://crates.io/crates/prometheus)
-[![Dependency Status](https://deps.rs/repo/github/tikv/rust-prometheus/status.svg)](https://deps.rs/repo/github/tikv/rust-prometheus)
 
 This is the [Rust](https://www.rust-lang.org) client library for
-[Prometheus](http://prometheus.io). The main Structures and APIs are ported from
-[Go client](https://github.com/prometheus/client_golang).
+[Prometheus](http://prometheus.io). The main data structures and APIs are ported
+from [Go client](https://github.com/prometheus/client_golang).
 
 
-### Documentation
+## Documentation
 
 Find the latest documentation at https://docs.rs/prometheus
+
+
+## Advanced
+
+### Features
+
+This library supports four features:
+
+- `gen`: To generate protobuf client with the latest protobuf version instead of
+  using the pre-generated client.
+
+- `nightly`: Enable nightly only features.
+
+- `push`: Enable push support.
+
+- `process`: For collecting process info.
+
+- `push`: Enable push support.
+
+
+### Static Metric
+
+Static metric helps you make metric vectors faster.
+
+See [static-metric](./static-metric) directory for details.
 
 
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -1,70 +1,19 @@
 # Prometheus Rust client library
 
-[![Build Status](https://travis-ci.org/pingcap/rust-prometheus.svg?branch=master)](https://travis-ci.org/pingcap/rust-prometheus)
+[![Build Status](https://travis-ci.org/tikv/rust-prometheus.svg?branch=master)](https://travis-ci.org/pingcap/rust-prometheus)
 [![docs.rs](https://docs.rs/prometheus/badge.svg)](https://docs.rs/prometheus)
 [![crates.io](http://meritbadge.herokuapp.com/prometheus)](https://crates.io/crates/prometheus)
 [![Dependency Status](https://deps.rs/repo/github/tikv/rust-prometheus/status.svg)](https://deps.rs/repo/github/tikv/rust-prometheus)
 
-This is the [Rust](https://www.rust-lang.org) client library for [Prometheus](http://prometheus.io).
-The main Structures and APIs are ported from [Go client](https://github.com/prometheus/client_golang).
+This is the [Rust](https://www.rust-lang.org) client library for
+[Prometheus](http://prometheus.io). The main Structures and APIs are ported from
+[Go client](https://github.com/prometheus/client_golang).
 
-## Usage
 
-- Add dependency to your `Cargo.toml`:
+### Documentation
 
-  ```toml
-  prometheus = "0.8"
-  ```
+Find the latest documentation at https://docs.rs/prometheus
 
-- Optional: Better performance for Rust nightly.
-
-  ```toml
-  prometheus = { version = "0.8", features = ["nightly"] }
-  ```
-
-### Note
-
-The crate has a pre-generated protobuf binding file for `protobuf` v2.0, if you need use the latest version of `protobuf`, you can generate the binding file on building with the `gen` feature.
-
-```toml
-prometheus = { version = "0.8", features = ["gen"] }
-```
-
-## Example
-
-```rust
-use prometheus::{Opts, Registry, Counter, TextEncoder, Encoder};
-
-// Create a Counter.
-let counter_opts = Opts::new("test_counter", "test counter help");
-let counter = Counter::with_opts(counter_opts).unwrap();
-
-// Create a Registry and register Counter.
-let r = Registry::new();
-r.register(Box::new(counter.clone())).unwrap();
-
-// Inc.
-counter.inc();
-
-// Gather the metrics.
-let mut buffer = vec![];
-let encoder = TextEncoder::new();
-let metric_families = r.gather();
-encoder.encode(&metric_families, &mut buffer).unwrap();
-
-// Output to the standard output.
-println!("{}", String::from_utf8(buffer).unwrap());
-```
-
-[More Examples](./examples)
-
-## Advanced
-
-### Static Metric
-
-Static metric helps you make metric vectors faster.
-
-See [static-metric](./static-metric) directory for details.
 
 ## Thanks
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,16 @@ The Rust client library for [Prometheus](https://prometheus.io/).
 
 Use of this library involves a few core concepts:
 
-* A number of [`Counter`](type.Counter.html)s that represent metrics from your system.
-* A [`Registry`](struct.Registry.html) with a number of registered [`Counter`s](type.Counter.html).
-* An endpoint that calls [`gather`](fn.gather.html) which returns a
-[`MetricFamily`](proto/struct.MetricFamily.html) through an [`Encoder`](trait.Encoder.html).
+* [`Metric`s](core/trait.Metric.html) like [`Counter`s](type.Counter.html) that
+  represent information about your system.
+
+* A [`Registry`](struct.Registry.html) that [`Metric`s](core/trait.Metric.html)
+  are registered with.
+
+* An endpoint that calls [`gather`](fn.gather.html) which returns
+  [`MetricFamily`s](proto/struct.MetricFamily.html) through an
+  [`Encoder`](trait.Encoder.html).
+
 
 # Basic Example
 
@@ -36,10 +42,14 @@ encoder.encode(&metric_families, &mut buffer).unwrap();
 println!("{}", String::from_utf8(buffer).unwrap());
 ```
 
+You can find more examples within
+[`/examples`](https://github.com/tikv/rust-prometheus/tree/master/examples).
+
+
 # Static Metrics
 
 This crate supports staticly built metrics. You can use it with
-[`lazy_static`](https://docs.rs/lazy_static/1.1.0/lazy_static/) to quickly build up and collect
+[`lazy_static`](https://docs.rs/lazy_static/) to quickly build up and collect
 some metrics.
 
 ```rust
@@ -86,13 +96,19 @@ const EXPECTED_OUTPUT: &'static str = "# HELP highfives Number of high fives rec
 assert!(output.starts_with(EXPECTED_OUTPUT));
 ```
 
+See [prometheus_static_metric](https://docs.rs/prometheus-static-metric) for
+additional functionality.
+
+
 # Features
 
 This library supports four features:
 
+* `gen`: To generate protobuf client with the latest protobuf version instead of
+  using the pre-generated client.
 * `nightly`: Enable nightly only features.
-* `push`: Enable push support.
 * `process`: For collecting process info.
+* `push`: Enable push support.
 
 */
 


### PR DESCRIPTION
- Move all documentation to src/lib linking to it within README (to ensure there is no mismatch)

- Fix build status link.

- Update crate feature documentation.

---

Replaces https://github.com/tikv/rust-prometheus/pull/330.