### PR TITLE
Remove proc-macro-hack

### DIFF
--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -15,7 +15,6 @@ include = [
 
 [dependencies]
 static-metric-proc-macros = { path = "./proc-macros" }
-proc-macro-hack = "0.5"
 
 [dev-dependencies]
 prometheus = { path = "../" }

--- a/static-metric/examples/register_integration.rs
+++ b/static-metric/examples/register_integration.rs
@@ -7,8 +7,6 @@ by using the `register_static_xxx!` macro provided by this crate.
 
 */
 
-#![feature(proc_macro_hygiene)]
-
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/static-metric/proc-macros/Cargo.toml
+++ b/static-metric/proc-macros/Cargo.toml
@@ -15,7 +15,6 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0"
-proc-macro-hack = "0.5"
 quote = "1.0"
 lazy_static = "1.4"
 

--- a/static-metric/proc-macros/src/lib.rs
+++ b/static-metric/proc-macros/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate lazy_static;
 extern crate proc_macro;
 extern crate proc_macro2;
-extern crate proc_macro_hack;
 #[macro_use]
 extern crate quote;
 extern crate syn;
@@ -22,7 +21,6 @@ use self::parser::StaticMetricMacroBody;
 use self::register_macro::RegisterMethodInvoking;
 use crate::auto_flush_from::AutoFlushFromDef;
 use auto_flush_builder::AutoFlushTokensBuilder;
-use proc_macro_hack::proc_macro_hack;
 
 /// Build static metrics.
 #[proc_macro]
@@ -40,7 +38,7 @@ pub fn make_auto_flush_static_metric(input: TokenStream) -> TokenStream {
 }
 
 /// Instantiate a auto flush able static metric struct from a HistogramVec or CounterVec.
-#[proc_macro_hack]
+#[proc_macro]
 pub fn auto_flush_from(input: TokenStream) -> TokenStream {
     let def: AutoFlushFromDef = syn::parse(input).unwrap();
     def.auto_flush_from().into()

--- a/static-metric/src/lib.rs
+++ b/static-metric/src/lib.rs
@@ -22,14 +22,9 @@ assert_eq!(HIGH_FIVE_COUNTER.get(), 1);
 Is it reccomended that you consult the [`prometheus` documentation for more information.](https://docs.rs/prometheus/)
 */
 
-extern crate proc_macro_hack;
 extern crate static_metric_proc_macros;
 
-use proc_macro_hack::proc_macro_hack;
-
-#[proc_macro_hack]
 pub use static_metric_proc_macros::auto_flush_from;
-
 pub use static_metric_proc_macros::{make_auto_flush_static_metric, make_static_metric};
 pub use static_metric_proc_macros::{
     register_static_counter_vec, register_static_gauge_vec, register_static_histogram_vec,


### PR DESCRIPTION
As of Rust 1.45,  `proc-macro-hack` is superseded by native support for #[proc_macro] in expression position.

Signed-off-by: koushiro <koushiro.cqx@gmail.com>