### PR TITLE
*: Prepare release candidate 0.10.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.10.0-rc.1
+
+- Improvement: Use different generic parameters for name and help at metric construction (#324).
+
+- Bug fix: Error instead of panic when constructing histogram with unequal label key and label value length (#326).
+
+- Bug fix: Return `Error::AlreadyReg` on duplicate collector registration (#333).
+
+- Bug fix: Make Histogram::observe atomic across collects (#314).
+
+- Internal change: Replace spin with parking_lot (#318).
+
+- Internal change: Optimize metric formatting (#327).
+
+- Internal change: Update parking_lot and procfs dependencies (#337).
+
 ## 0.9.0
 
 - Add: Implement `encode` function for summary type metrics. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-version = "0.9.0"
+version = "0.10.0-rc.1"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -23,7 +23,7 @@ quote = "1.0"
 lazy_static = "1.4"
 
 [dev-dependencies]
-prometheus = { version = "0.9", path = "../" }
+prometheus = { version = "0.10.0-rc.1", path = "../" }
 
 [features]
 default = []

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-static-metric"
-version = "0.4.0"
+version = "0.5.0-rc.1"
 license = "Apache-2.0"
 authors = ["me@breeswish.org"]
 description = "Static metric helper utilities for rust-prometheus."


### PR DESCRIPTION
Following the basic release approach suggested in https://github.com/tikv/rust-prometheus/issues/305#issuecomment-654729638 to create a release candidate (`0.10.0-rc.1`).

Once this is merged I would:

1. Create and push a git tag.

    ```bash
    tag="v$(sed -En 's/^version = \"(.*)\"$/\1/p' Cargo.toml)"
    git tag -s "${tag}" -m "${tag}"
    git push libp2p --tags --dry-run
    git push libp2p --tags
    ```

2. Publish to crates.io.

    ```
    cargo clean
    git clean -fd
    cargo publish --dry-run
    cargo publish
    ```

I am still not against the more advanced release process for future releases suggested by @lucab in https://github.com/tikv/rust-prometheus/issues/305#issuecomment-658083355.