### PR TITLE
*: Prepare release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.0-rc.1
+## 0.10.0
 
 - Improvement: Use different generic parameters for name and help at metric construction (#324).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-version = "0.10.0-rc.1"
+version = "0.10.0"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -23,7 +23,7 @@ quote = "1.0"
 lazy_static = "1.4"
 
 [dev-dependencies]
-prometheus = { version = "0.10.0-rc.1", path = "../" }
+prometheus = { version = "0.10.0", path = "../" }
 
 [features]
 default = []


### PR DESCRIPTION
Follow up to release candidate https://github.com/tikv/rust-prometheus/pull/340.

We (Parity) have been running `v0.10.0-rc.1` on two Kusama (testnetwork) nodes since last week Thursday (27th). I have not seen any abnormal behavior on either of the two. (Ref: https://github.com/paritytech/substrate/pull/6964)

With the above in mind I am suggesting to promote the release candidate to the `v0.10.0` release. Any objections?