### PR TITLE
Update "features" section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ from [Go client](https://github.com/prometheus/client_golang).
 
 ## Documentation
 
-Find the latest documentation at [docs.rs](https://docs.rs/prometheus)
+Find the latest documentation at <https://docs.rs/prometheus>.
 
 ## Advanced
 
 ### Crate features
 
-Some of the crate features need to be enabled before they can be used. Use `features = []` flag in `Cargo.toml` to enable them:
+This crate provides several optional components which can be enabled via [Cargo `[features]`](https://doc.rust-lang.org/cargo/reference/features.html):
 
 - `gen`: To generate protobuf client with the latest protobuf version instead of
   using the pre-generated client.
 
 - `nightly`: Enable nightly only features.
 
-- `process`: For collecting process info.
+- `process`: Enable [process metrics](https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics) support.
 
 - `push`: Enable [push metrics](https://prometheus.io/docs/instrumenting/pushing/) support.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Find the latest documentation at https://docs.rs/prometheus
 
 ## Advanced
 
-### Features
+### Crate features
 
-This library supports four features:
+Some of the crate features need to be enabled before they can be used. Use `features = []` flag in `Cargo.toml` to enable them:
 
 - `gen`: To generate protobuf client with the latest protobuf version instead of
   using the pre-generated client.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some of the crate features need to be enabled before they can be used. Use `feat
 
 - `process`: For collecting process info.
 
-- `push`: Enable push support.
+- `push`: Enable [push metrics](https://prometheus.io/docs/instrumenting/pushing/) support.
 
 ### Static Metric
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ This is the [Rust](https://www.rust-lang.org) client library for
 [Prometheus](http://prometheus.io). The main data structures and APIs are ported
 from [Go client](https://github.com/prometheus/client_golang).
 
-
 ## Documentation
 
-Find the latest documentation at https://docs.rs/prometheus
-
+Find the latest documentation at [docs.rs](https://docs.rs/prometheus)
 
 ## Advanced
 
@@ -29,7 +27,6 @@ Some of the crate features need to be enabled before they can be used. Use `feat
 
 - `push`: Enable push support.
 
-
 ### Static Metric
 
 When using a `MetricVec` with label values known at compile time
@@ -37,7 +34,6 @@ prometheus-static-metric reduces the overhead of retrieving the concrete
 `Metric` from a `MetricVec`.
 
 See [static-metric](./static-metric) directory for details.
-
 
 ## Thanks
 


### PR DESCRIPTION
Changelog:
- Update wording in **feature** section to indicate that there are crate features which need to be enabled before they can be used
- Run markdownlint on README
- Add link for word **push metrics** to show what the push metrics support actually is

Reason:
Reduce confusion as to if the feature section talks about library features or crate features.

Fixes #345 