### PR TITLE
Support adding prefix to metric name by env variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ gen = ["protobuf-codegen-pure"]
 nightly = ["libc"]
 process = ["libc", "procfs"]
 push = ["reqwest", "libc", "protobuf"]
+metric-name-prefix=[]
 
 [dependencies]
 cfg-if = "^0.1"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -112,10 +112,20 @@ pub struct Opts {
 impl Opts {
     /// `new` creates the Opts with the `name` and `help` arguments.
     pub fn new<S1: Into<String>, S2: Into<String>>(name: S1, help: S2) -> Opts {
+        let name = {
+            let converted = name.into();
+            #[cfg(feature = "metric-name-prefix")]
+            let converted = if let Some(p) = option_env!("PROMETHEUS_METRIC_NAME_PREFIX") {
+                p.to_string() + converted.as_str()
+            } else {
+                converted.into()
+            };
+            converted
+        };
         Opts {
             namespace: "".to_owned(),
             subsystem: "".to_owned(),
-            name: name.into(),
+            name,
             help: help.into(),
             const_labels: HashMap::new(),
             variable_labels: Vec::new(),


### PR DESCRIPTION
For some reason, we need to batch add prefix to metric name rather than modifying code.
Implement it as a new feature.