### PR TITLE
static-metric/src/parser: Allow not specifying visibility

### DIFF
--- a/static-metric/CHANGELOG.md
+++ b/static-metric/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for prometheus-static-metric
 
+## 0.5.0 [unreleased]
+
+- Bug fix: Allow not specifying visibility token (e.g. `pub(crate)`) for metric definition.
+
 ## 0.4.0
 
 - Misc: Update dependencies (https://github.com/tikv/rust-prometheus/pull/289, https://github.com/tikv/rust-prometheus/pull/311)

--- a/static-metric/src/parser.rs
+++ b/static-metric/src/parser.rs
@@ -251,7 +251,7 @@ pub enum StaticMetricMacroBodyItem {
 
 impl Parse for StaticMetricMacroBodyItem {
     fn parse(input: ParseStream) -> Result<Self> {
-        if input.peek2(Token!(struct)) || input.peek2(Token!(struct)) {
+        if input.peek(Token!(struct)) || input.peek2(Token!(struct)) {
             Ok(StaticMetricMacroBodyItem::Metric(input.parse()?))
         } else {
             Ok(StaticMetricMacroBodyItem::Enum(input.parse()?))

--- a/static-metric/tests/metric.rs
+++ b/static-metric/tests/metric.rs
@@ -37,6 +37,10 @@ make_static_metric! {
             bar: "bar_name",
         },
     }
+
+    struct NonPubCounterVec: Counter {
+        "method" => Methods,
+    }
 }
 
 /// Helper method to get a label values of a `Counter`.


### PR DESCRIPTION
When determining whether to parse a struct or an enum the `Parse`
implementation for `StaticMetricMacroBodyItem` checks for the tokens
`struct` or `enum`. Given that the two can optionally be preceeded by
a visibility token (e.g. `pub(crate)`) one needs to peek at both the
first and the second token.

Follow up on https://github.com/tikv/rust-prometheus/pull/268/.