### PR TITLE
.travis.yml: Run benchmarks on each run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,8 @@ script:
     if [ $TRAVIS_RUST_VERSION = 'nightly' ]; then
         cargo build -p prometheus-static-metric --examples --no-default-features --features="$FEATURES"
         cargo test -p prometheus-static-metric --no-default-features --features="$FEATURES"
+
+        # Run benchmarks.
+        cargo bench --no-default-features --features="$FEATURES"
+        cargo bench -p prometheus-static-metric --no-default-features --features="$FEATURES"
     fi


### PR DESCRIPTION
Run benchmarks on each pull request to ensure they compile and won't panic. 

In the long run we might want to remove the line below fixing the nightly version instead.

```yaml
  allow_failures:
  - rust: nightly
```

Signed-off-by: Max Inden <mail@max-inden.de>