### PR TITLE
src/desc: Validate metric and label names via regex crate

### DIFF
--- a/benches/desc.rs
+++ b/benches/desc.rs
@@ -1,0 +1,31 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(test)]
+
+extern crate test;
+
+use prometheus::core::Desc;
+
+use test::{Bencher, black_box};
+
+#[bench]
+fn description_validation(b: &mut Bencher) {
+    b.iter(|| black_box(Desc::new(
+        "api_http_requests_total".to_string(),
+        "not empty help".to_string(),
+        vec!["method".to_string(), "handler".to_string()],
+        Default::default(),
+    )));
+}
+

--- a/benches/desc.rs
+++ b/benches/desc.rs
@@ -17,15 +17,16 @@ extern crate test;
 
 use prometheus::core::Desc;
 
-use test::{Bencher, black_box};
+use test::{black_box, Bencher};
 
 #[bench]
 fn description_validation(b: &mut Bencher) {
-    b.iter(|| black_box(Desc::new(
-        "api_http_requests_total".to_string(),
-        "not empty help".to_string(),
-        vec!["method".to_string(), "handler".to_string()],
-        Default::default(),
-    )));
+    b.iter(|| {
+        black_box(Desc::new(
+            "api_http_requests_total".to_string(),
+            "not empty help".to_string(),
+            vec!["method".to_string(), "handler".to_string()],
+            Default::default(),
+        ))
+    });
 }
-

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -5,53 +5,30 @@ use std::collections::{BTreeSet, HashMap};
 use std::hash::Hasher;
 
 use fnv::FnvHasher;
+use regex::Regex;
 
 use crate::errors::{Error, Result};
 use crate::metrics::SEPARATOR_BYTE;
 use crate::proto::LabelPair;
 
 // Details of required format are at
-//   https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 fn is_valid_metric_name(name: &str) -> bool {
-    // Valid metric names must match regex [a-zA-Z_:][a-zA-Z0-9_:]*.
-    fn valid_start(c: char) -> bool {
-        c.is_ascii()
-            && match c as u8 {
-                b'a'..=b'z' | b'A'..=b'Z' | b'_' | b':' => true,
-                _ => false,
-            }
+    lazy_static! {
+        static ref VALIDATOR: Regex = Regex::new("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+            .expect("Regex to be valid.");
     }
 
-    fn valid_char(c: char) -> bool {
-        c.is_ascii()
-            && match c as u8 {
-                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b':' => true,
-                _ => false,
-            }
-    }
-
-    name.starts_with(valid_start) && !name.contains(|c| !valid_char(c))
+    VALIDATOR.is_match(name)
 }
 
 fn is_valid_label_name(name: &str) -> bool {
-    // Valid label names must match regex [a-zA-Z_][a-zA-Z0-9_]*.
-    fn valid_start(c: char) -> bool {
-        c.is_ascii()
-            && match c as u8 {
-                b'a'..=b'z' | b'A'..=b'Z' | b'_' => true,
-                _ => false,
-            }
+    lazy_static! {
+        static ref VALIDATOR: Regex = Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*$")
+            .expect("Regex to be valid.");
     }
 
-    fn valid_char(c: char) -> bool {
-        c.is_ascii()
-            && match c as u8 {
-                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => true,
-                _ => false,
-            }
-    }
-
-    name.starts_with(valid_start) && !name.contains(|c| !valid_char(c))
+    VALIDATOR.is_match(name)
 }
 
 /// The descriptor used by every Prometheus [`Metric`](crate::core::Metric). It is essentially

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -15,8 +15,8 @@ use crate::proto::LabelPair;
 // https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 fn is_valid_metric_name(name: &str) -> bool {
     lazy_static! {
-        static ref VALIDATOR: Regex = Regex::new("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
-            .expect("Regex to be valid.");
+        static ref VALIDATOR: Regex =
+            Regex::new("^[a-zA-Z_:][a-zA-Z0-9_:]*$").expect("Regex to be valid.");
     }
 
     VALIDATOR.is_match(name)
@@ -24,8 +24,8 @@ fn is_valid_metric_name(name: &str) -> bool {
 
 fn is_valid_label_name(name: &str) -> bool {
     lazy_static! {
-        static ref VALIDATOR: Regex = Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*$")
-            .expect("Regex to be valid.");
+        static ref VALIDATOR: Regex =
+            Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*$").expect("Regex to be valid.");
     }
 
     VALIDATOR.is_match(name)


### PR DESCRIPTION
Current CI runs fail (see https://github.com/tikv/rust-prometheus/pull/353) due to the following Clippy warning:

```
error: match expression looks like `matches!` macro
  --> src/desc.rs:19:16
   |
19 |               && match c as u8 {
   |  ________________^
20 | |                 b'a'..=b'z' | b'A'..=b'Z' | b'_' | b':' => true,
21 | |                 _ => false,
22 | |             }
   | |_____________^ help: try this: `matches!(c as u8, b'a'..=b'z' | b'A'..=b'Z' | b'_' | b':')`
   |
   = note: `-D clippy::match-like-matches-macro` implied by `-D clippy`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
```

Instead of using `matches!` I propose to remove the entire manual validation in favor of a simple regex.

For those worried about performance, even though I doubt this code path is performance crticial, I added a basic benchmark showing not a regression but a slight speed-up.

```bash
$ cargo benchcmp manual regex
 name                    manual ns/iter  regex ns/iter  diff ns/iter  diff %  speedup 
 description_validation  684             665                     -19  -2.78%   x 1.03

$ cat /proc/cpuinfo | grep "model name" | head -1
model name      : Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
```