### PR TITLE
static-metric/src/builder: Allow non-public label enums

### DIFF
--- a/static-metric/src/builder.rs
+++ b/static-metric/src/builder.rs
@@ -199,7 +199,7 @@ impl<'a> MetricBuilderContext<'a> {
 
         quote! {
             #[allow(missing_copy_implementations)]
-            pub struct #struct_name {
+            pub(super) struct #struct_name {
                 #(
                     pub #field_names: #member_types,
                 )*


### PR DESCRIPTION
Imagine the following static metric generation:

```rust
make_static_metric! {
    label_enum Methods {
        post,
        get,
    }

    struct MyStaticCounterVec: Counter {
        "method" => Methods,
    }
}
```

This will roughly expand to:

```rust
enum Methods {
    post,
    get,
}

use self::prometheus_static_scope_0::MyStaticCounterVec;
mod prometheus_static_scope_0 {
    pub struct MyStaticCounterVec {
        pub post: MyStaticCounterVec2,
        pub get: MyStaticCounterVec2,
    }
}
```

Rustc would complain that the `private type 'Methods' [is] in [the]
public interface (error E0446)` `MyStaticCounterVec`.

There is no reason for `MyStaticCounterVec` to be defined with
visibility `pub`. This commit instead defines `MyStaticCounterVec` with
`pub(super)` and thus `MyStaticCounterVec` does not expose the private
type `Methods`.

Signed-off-by: Max Inden <mail@max-inden.de>