### PR TITLE
Switch to more efficient fd_count() for process_open_fds

### DIFF
--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -132,8 +132,8 @@ impl Collector for ProcessCollector {
         };
 
         // file descriptors
-        if let Ok(fd_list) = p.fd() {
-            self.open_fds.set(fd_list.len() as f64);
+        if let Ok(fd_count) = p.fd_count() {
+            self.open_fds.set(fd_count as f64);
         }
         if let Ok(limits) = p.limits() {
             if let procfs::process::LimitValue::Value(max) = limits.max_open_files.soft_limit {


### PR DESCRIPTION
Picking up https://github.com/eminence/procfs/pull/105.

For a service with 80k open file descriptors this reduces metric collection time from 500ms down to 100ms (no contention).