### PR TITLE
*: Follow metric naming convention for unit-less count

### DIFF
--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -15,7 +15,7 @@ use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
 lazy_static! {
     static ref HTTP_COUNTER: Counter = register_counter!(opts!(
         "example_http_requests_total",
-        "Total number of HTTP requests made.",
+        "Number of HTTP requests made.",
         labels! {"handler" => "all",}
     ))
     .unwrap();

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -249,7 +249,7 @@ impl<T: MetricVecBuilder> MetricVec<T> {
     /// ```
     /// use prometheus::{CounterVec, Opts};
     /// let vec = CounterVec::new(
-    ///     Opts::new("requests", "Number of requests"),
+    ///     Opts::new("requests_total", "Number of requests."),
     ///     &["code", "http_method"]
     /// ).unwrap();
     /// vec.with_label_values(&["404", "POST"]).inc()

--- a/static-metric/README.md
+++ b/static-metric/README.md
@@ -125,8 +125,8 @@ make_auto_flush_static_metric! {
 lazy_static! {
     pub static ref HTTP_COUNTER_VEC: IntCounterVec =
         register_int_counter_vec ! (
-            "http_requests",
-            "Total number of HTTP requests.",
+            "http_requests_total",
+            "Number of HTTP requests.",
             & ["product", "method", "version"]    // it doesn't matter for the label order
         ).unwrap();
 }

--- a/static-metric/examples/advanced.rs
+++ b/static-metric/examples/advanced.rs
@@ -31,8 +31,8 @@ make_static_metric! {
 lazy_static! {
     pub static ref HTTP_COUNTER_VEC: IntCounterVec =
         register_int_counter_vec!(
-            "http_requests",
-            "Total number of HTTP requests.",
+            "http_requests_total",
+            "Number of HTTP requests.",
             &["product", "method", "version"]    // it doesn't matter for the label order
         ).unwrap();
 

--- a/static-metric/examples/local.rs
+++ b/static-metric/examples/local.rs
@@ -34,8 +34,8 @@ make_static_metric! {
 lazy_static! {
     pub static ref HTTP_COUNTER_VEC: IntCounterVec =
         register_int_counter_vec!(
-            "http_requests",
-            "Total number of HTTP requests.",
+            "http_requests_total",
+            "Number of HTTP requests.",
             &["product", "method", "version"]    // it doesn't matter for the label order
         ).unwrap();
 }

--- a/static-metric/examples/make_auto_flush_static_counter.rs
+++ b/static-metric/examples/make_auto_flush_static_counter.rs
@@ -41,8 +41,8 @@ make_auto_flush_static_metric! {
 lazy_static! {
     pub static ref HTTP_COUNTER_VEC: IntCounterVec =
         register_int_counter_vec ! (
-            "http_requests",
-            "Total number of HTTP requests.",
+            "http_requests_total",
+            "Number of HTTP requests.",
             & ["product", "method", "version"]    // it doesn't matter for the label order
         ).unwrap();
 }
@@ -377,8 +377,8 @@ impl Lhrs {
 lazy_static! {
 pub static ref HTTP_COUNTER_VEC: IntCounterVec =
 register_int_counter_vec ! (
-"http_requests",
-"Total number of HTTP requests.",
+"http_requests_total",
+"Number of HTTP requests.",
 & ["product", "method", "version"]    // it doesn't matter for the label order
 ).unwrap();
 }

--- a/static-metric/examples/make_auto_flush_static_metric_histogram.rs
+++ b/static-metric/examples/make_auto_flush_static_metric_histogram.rs
@@ -41,8 +41,8 @@ make_auto_flush_static_metric! {
 lazy_static! {
     pub static ref HTTP_HISTO_VEC: HistogramVec =
         register_histogram_vec ! (
-            "http_requests",
-            "Total number of HTTP requests.",
+            "http_requests_total",
+            "Number of HTTP requests.",
             & ["product", "method", "version"]    // it doesn't matter for the label order
         ).unwrap();
 }
@@ -371,8 +371,8 @@ impl Lhrs {
 lazy_static! {
 pub static ref HTTP_HISTO_VEC: HistogramVec =
 register_histogram_vec ! (
-"http_requests",
-"Total number of HTTP requests.",
+"http_requests_total",
+"Number of HTTP requests.",
 & ["product", "method", "version"]    // it doesn't matter for the label order
 ).unwrap();
 }

--- a/static-metric/examples/register_integration.rs
+++ b/static-metric/examples/register_integration.rs
@@ -42,8 +42,8 @@ make_static_metric! {
 lazy_static! {
     pub static ref HTTP_COUNTER: HttpRequestStatistics = register_static_counter_vec!(
         HttpRequestStatistics,
-        "http_requests",
-        "Total number of HTTP requests.",
+        "http_requests_total",
+        "Number of HTTP requests.",
         &["method", "product"]
     )
     .unwrap();

--- a/static-metric/examples/with_lazy_static.rs
+++ b/static-metric/examples/with_lazy_static.rs
@@ -26,8 +26,8 @@ make_static_metric! {
 
 lazy_static! {
     pub static ref HTTP_COUNTER_VEC: CounterVec = register_counter_vec!(
-        "http_requests",
-        "Total number of HTTP requests.",
+        "http_requests_total",
+        "Number of HTTP requests.",
         &["method", "product"]
     )
     .unwrap();


### PR DESCRIPTION
By convention unit-less Prometheus counters are postfixed with `_total`.
See https://prometheus.io/docs/practices/naming/ for details.