### PR TITLE
*: Prepare prometheus v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.11.0
+
+- Improvement: Switch to more efficient `fd_count()` for `process_open_fds` (#357).
+
+- API change: Change Integer Counter type from AtomicI64 to AtomicU64 (#365).
+
+- Internal change: Update dependencies.
+
 ## 0.10.0
 
 - Improvement: Use different generic parameters for name and help at metric construction (#324).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-version = "0.10.0"
+version = "0.11.0"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 criterion = "0.3"
-prometheus = { version = "0.10.0", path = "../" }
+prometheus = { version = "0.11.0", path = "../" }
 
 [features]
 default = []


### PR DESCRIPTION
As you can see by CHANGELOG.md the list of changes is not long. Still to keep the release cycle short I am proposing to release `prometheus` `v0.11.0`.

Once this is released I can as well cut `prometheus-static-metric` `v0.5.0`.

What do you think?