### PR TITLE
static-metric: Prepare release v0.5.0

### DIFF
--- a/static-metric/CHANGELOG.md
+++ b/static-metric/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for prometheus-static-metric
 
-## 0.5.0 [unreleased]
+## 0.5.0
 
 - Bug fix: Allow not specifying visibility token (e.g. `pub(crate)`) for metric definition.
 

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-static-metric"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 license = "Apache-2.0"
 authors = ["me@breeswish.org"]
 description = "Static metric helper utilities for rust-prometheus."


### PR DESCRIPTION
Follow up for https://github.com/tikv/rust-prometheus/pull/370 cutting a new release of `prometheus-static-metric` as well.

Signed-off-by: Max Inden <mail@max-inden.de>