### PR TITLE
static-metric/Cargo.toml: Remove include section

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
         run: cargo fmt --all -- --check -l
       - name: cargo clippy
         run: cargo clippy --all -- -D clippy
+      - name: cargo package
+        run : cargo package && cargo package --manifest-path static-metric/Cargo.toml
   criterion:
     name: "Benchmarks (criterion)"
     runs-on: ubuntu-latest

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -11,6 +11,7 @@ include = [
     "LICENSE",
     "Cargo.toml",
     "src/**/*.rs",
+    "benches/*.rs",
 ]
 
 [lib]

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -11,7 +11,6 @@ include = [
     "LICENSE",
     "Cargo.toml",
     "src/**/*.rs",
-    "benches/*.rs",
 ]
 
 [lib]

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -7,11 +7,6 @@ description = "Static metric helper utilities for rust-prometheus."
 repository = "https://github.com/tikv/rust-prometheus"
 homepage = "https://github.com/tikv/rust-prometheus"
 documentation = "https://docs.rs/prometheus-static-metric"
-include = [
-    "LICENSE",
-    "Cargo.toml",
-    "src/**/*.rs",
-]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Releasing static-metric fails with:

```
Caused by:
  failed to parse manifest at
`/xxx/tikv/rust-prometheus/target/package/prometheus-static-metric-0.5.0/Cargo.toml`

Caused by:
  can't find `benches` bench, specify bench.path
```

This is due to the `benches` folder not being included in the final
release tarball. With this commit the folder is included and thus
releasing prometheus-static-metric would succeed.

Off the top of my head this is the right way to go. Open for alternative
suggestions.