### PR TITLE
static-metric: Prepare release v0.5.1

### DIFF
--- a/static-metric/CHANGELOG.md
+++ b/static-metric/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for prometheus-static-metric
 
+## 0.5.1
+
+- Import `TokenStream` via `proc_macro` instead of `syn` to support `syn`
+  `>= 1.0.58` (https://github.com/tikv/rust-prometheus/issues/378).
+
 ## 0.5.0
 
 - Bug fix: Allow not specifying visibility token (e.g. `pub(crate)`) for metric definition.

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-static-metric"
-version = "0.5.0"
+version = "0.5.1"
 license = "Apache-2.0"
 authors = ["me@breeswish.org"]
 description = "Static metric helper utilities for rust-prometheus."


### PR DESCRIPTION
I would like to cut `static-metric` `v0.5.1` so others can make use of the fix for https://github.com/tikv/rust-prometheus/issues/378.

//CC @fggarcia