### PR TITLE
desc: fix format string for panic

### DIFF
--- a/src/desc.rs
+++ b/src/desc.rs
@@ -257,7 +257,7 @@ mod tests {
             .expect(format!("expected error for {}", name).as_ref());
             match res {
                 Error::Msg(msg) => assert_eq!(msg, format!("'{}' is not a valid label name", name)),
-                other => panic!(other),
+                other => panic!("{}", other),
             };
         }
     }
@@ -272,7 +272,7 @@ mod tests {
                 .expect(format!("expected error for {}", name).as_ref());
             match res {
                 Error::Msg(msg) => assert_eq!(msg, format!("'{}' is not a valid label name", name)),
-                other => panic!(other),
+                other => panic!("{}", other),
             };
         }
     }
@@ -287,7 +287,7 @@ mod tests {
                 Error::Msg(msg) => {
                     assert_eq!(msg, format!("'{}' is not a valid metric name", name))
                 }
-                other => panic!(other),
+                other => panic!("{}", other),
             };
         }
     }


### PR DESCRIPTION
This fixes a compile error on current beta toolchain, which started
enforcing that panic messages must be string literals (with format
specifiers).