### PR TITLE
prometheus: release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.12.0
+
+ - Improvement: Fix format string in panic!() calls (#391)
+
+ - Improvement: Replace regex with memchr (#385)
+
+ - Improvement: Update reqwest requirement from ^0.10 to ^0.11 (#379)
+
 ## 0.11.0
 
 - Improvement: Switch to more efficient `fd_count()` for `process_open_fds` (#357).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-version = "0.11.0"
+version = "0.12.0"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 criterion = "0.3"
-prometheus = { version = "0.11.0", path = "../" }
+prometheus = { path = "../" }
 
 [features]
 default = []


### PR DESCRIPTION
## 0.12.0

 - Improvement: Fix format string in panic!() calls (#391)

 - Improvement: Replace regex with memchr (#385)

 - Improvement: Update reqwest requirement from ^0.10 to ^0.11 (#379)

Closes: https://github.com/tikv/rust-prometheus/issues/394