### PR TITLE
Clean up the use of macro_use and extern crate

### DIFF
--- a/examples/example_custom_registry.rs
+++ b/examples/example_custom_registry.rs
@@ -3,13 +3,11 @@
 //! This examples shows how to use multiple and custom registries,
 //! and how to perform registration across function boundaries.
 
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-
 use std::collections::HashMap;
 
 use prometheus::{Encoder, IntCounter, Registry};
+
+use lazy_static::lazy_static;
 
 lazy_static! {
     static ref DEFAULT_COUNTER: IntCounter = IntCounter::new("default", "generic counter").unwrap();

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -1,16 +1,14 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate prometheus;
-
 use hyper::{
     header::CONTENT_TYPE,
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server,
 };
 use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
+
+use lazy_static::lazy_static;
+use prometheus::{labels, opts, register_counter, register_gauge, register_histogram_vec};
 
 lazy_static! {
     static ref HTTP_COUNTER: Counter = register_counter!(opts!(

--- a/examples/example_int_metrics.rs
+++ b/examples/example_int_metrics.rs
@@ -1,11 +1,11 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate prometheus;
-
 use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+
+use lazy_static::lazy_static;
+use prometheus::{
+    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
+};
 
 lazy_static! {
     static ref A_INT_COUNTER: IntCounter =

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -2,17 +2,15 @@
 
 #![cfg_attr(not(feature = "push"), allow(unused_imports, dead_code))]
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate prometheus;
-
 use std::env;
 use std::thread;
 use std::time;
 
 use getopts::Options;
 use prometheus::{Counter, Histogram};
+
+use lazy_static::lazy_static;
+use prometheus::{labels, register_counter, register_histogram};
 
 lazy_static! {
     static ref PUSH_COUNTER: Counter = register_counter!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,10 @@ This crate supports staticly built metrics. You can use it with
 some metrics.
 
 ```rust
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate prometheus;
 use prometheus::{self, IntCounter, TextEncoder, Encoder};
+
+use lazy_static::lazy_static;
+use prometheus::register_int_counter;
 
 lazy_static! {
     static ref HIGH_FIVE_COUNTER: IntCounter =
@@ -71,10 +72,11 @@ By default, this registers with a default registry. To make a report, you can ca
 [`Encoder`](trait.Encoder.html) and report to Promethus.
 
 ```
-# #[macro_use] extern crate lazy_static;
-#[macro_use] extern crate prometheus;
 # use prometheus::IntCounter;
 use prometheus::{self, TextEncoder, Encoder};
+
+use lazy_static::lazy_static;
+use prometheus::register_int_counter;
 
 // Register & measure some metrics.
 # lazy_static! {
@@ -144,11 +146,6 @@ macro_rules! from_vec {
         $e
     };
 }
-
-#[macro_use]
-extern crate cfg_if;
-#[macro_use]
-extern crate lazy_static;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,8 +5,8 @@
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
 /// # use std::collections::HashMap;
+/// # use prometheus::labels;
 /// # fn main() {
 /// let labels = labels!{
 ///     "test" => "hello",
@@ -41,7 +41,7 @@ macro_rules! labels {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{labels, opts};
 /// # fn main() {
 /// let name = "test_opts";
 /// let help = "test opts help";
@@ -87,8 +87,8 @@ macro_rules! opts {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
 /// # use prometheus::linear_buckets;
+/// # use prometheus::{histogram_opts, labels};
 /// # fn main() {
 /// let name = "test_histogram_opts";
 /// let help = "test opts help";
@@ -135,7 +135,7 @@ macro_rules! histogram_opts {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{opts, register_counter};
 /// # fn main() {
 /// let opts = opts!("test_macro_counter_1", "help");
 /// let res1 = register_counter!(opts);
@@ -189,7 +189,7 @@ macro_rules! __register_counter_vec {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{opts, register_counter_vec};
 /// # fn main() {
 /// let opts = opts!("test_macro_counter_vec_1", "help");
 /// let counter_vec = register_counter_vec!(opts, &["a", "b"]);
@@ -238,7 +238,7 @@ macro_rules! __register_gauge {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{opts, register_gauge};
 /// # fn main() {
 /// let opts = opts!("test_macro_gauge", "help");
 /// let res1 = register_gauge!(opts);
@@ -287,7 +287,7 @@ macro_rules! __register_gauge_vec {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{opts, register_gauge_vec};
 /// # fn main() {
 /// let opts = opts!("test_macro_gauge_vec_1", "help");
 /// let gauge_vec = register_gauge_vec!(opts, &["a", "b"]);
@@ -327,7 +327,7 @@ macro_rules! register_int_gauge_vec {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{histogram_opts, register_histogram};
 /// # fn main() {
 /// let opts = histogram_opts!("test_macro_histogram", "help");
 /// let res1 = register_histogram!(opts);
@@ -363,7 +363,7 @@ macro_rules! register_histogram {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate prometheus;
+/// # use prometheus::{histogram_opts, register_histogram_vec};
 /// # fn main() {
 /// let opts = histogram_opts!("test_macro_histogram_vec_1", "help");
 /// let histogram_vec = register_histogram_vec!(opts, &["a", "b"]);

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -6,6 +6,8 @@
 
 use std::sync::Mutex;
 
+use lazy_static::lazy_static;
+
 use crate::counter::Counter;
 use crate::desc::Desc;
 use crate::gauge::Gauge;

--- a/src/push.rs
+++ b/src/push.rs
@@ -10,6 +10,8 @@ use reqwest::blocking::Client;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::{Method, StatusCode, Url};
 
+use lazy_static::lazy_static;
+
 use crate::encoder::{Encoder, ProtobufEncoder};
 use crate::errors::{Error, Result};
 use crate::metrics::Collector;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,6 +12,9 @@ use crate::errors::{Error, Result};
 use crate::metrics::Collector;
 use crate::proto;
 
+use cfg_if::cfg_if;
+use lazy_static::lazy_static;
+
 struct RegistryCore {
     pub collectors_by_id: HashMap<u64, Box<dyn Collector>>,
     pub dim_hashes_by_name: HashMap<String, u64>,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,6 +2,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use lazy_static::lazy_static;
+
 /// Milliseconds since ANCHOR.
 static RECENT: AtomicU64 = AtomicU64::new(0);
 lazy_static! {

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -7,6 +7,7 @@ description = "Static metric helper utilities for rust-prometheus."
 repository = "https://github.com/tikv/rust-prometheus"
 homepage = "https://github.com/tikv/rust-prometheus"
 documentation = "https://docs.rs/prometheus-static-metric"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/static-metric/Makefile
+++ b/static-metric/Makefile
@@ -10,6 +10,8 @@ build:
 test:
 	cargo test --features="${ENABLE_FEATURES}" -- --nocapture
 
+dev: format test
+
 format:
 	@cargo fmt --all -- --check >/dev/null || cargo fmt --all
 

--- a/static-metric/README.md
+++ b/static-metric/README.md
@@ -46,7 +46,7 @@ introducing a lot of templating code.
 - Add to `lib.rs`:
 
   ```rust
-  extern crate prometheus_static_metric;
+  use prometheus_static_metric;
   ```
 
 ## Example
@@ -89,14 +89,10 @@ fn main() {
 For heavier scenario that a global shared static-metric might not be effecient enough, you can use `make_auto_flush_static_metric!` macro, which will store data in local thread storage, with a custom rate to flush to global `MetricVec`.
 
 ```rust
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::*;
-use prometheus_static_metric::auto_flush_from;
-use prometheus_static_metric::make_auto_flush_static_metric;
+
+use lazy_static:lazy_static;
+use prometheus_static_metric::{auto_flush_from, make_auto_flush_static_metric};
 
 make_auto_flush_static_metric! {
 

--- a/static-metric/benches/benches.rs
+++ b/static-metric/benches/benches.rs
@@ -1,11 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-extern crate criterion;
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use prometheus::{IntCounter, IntCounterVec, Opts};
+
 use prometheus_static_metric::make_static_metric;
 
 /// Single `IntCounter` performance.

--- a/static-metric/examples/advanced.rs
+++ b/static-metric/examples/advanced.rs
@@ -1,12 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::IntCounterVec;
+
+use lazy_static::lazy_static;
+use prometheus::register_int_counter_vec;
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {

--- a/static-metric/examples/local.rs
+++ b/static-metric/examples/local.rs
@@ -1,13 +1,10 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use std::cell::Cell;
 
 use prometheus::*;
+
+use lazy_static::lazy_static;
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {

--- a/static-metric/examples/make_auto_flush_static_counter.rs
+++ b/static-metric/examples/make_auto_flush_static_counter.rs
@@ -5,14 +5,10 @@
 Use metric enums to reuse possible values of a label.
 
 */
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::*;
-use prometheus_static_metric::auto_flush_from;
-use prometheus_static_metric::make_auto_flush_static_metric;
+
+use lazy_static::lazy_static;
+use prometheus_static_metric::{auto_flush_from, make_auto_flush_static_metric};
 
 make_auto_flush_static_metric! {
 
@@ -95,11 +91,6 @@ fn main() {
 /*
 
 /// Pseudo macro expanded code of make_auto_flush_static_counter
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use std::cell::Cell;
 
 #[allow(unused_imports)]
@@ -109,6 +100,8 @@ use std::collections::HashMap;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::thread::LocalKey;
+
+use lazy_static::lazy_static;
 
 #[allow(dead_code)]
 #[allow(non_camel_case_types)]

--- a/static-metric/examples/make_auto_flush_static_metric_histogram.rs
+++ b/static-metric/examples/make_auto_flush_static_metric_histogram.rs
@@ -5,14 +5,11 @@
 Use metric enums to reuse possible values of a label.
 
 */
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-extern crate prometheus_static_metric;
 
 use prometheus::*;
-use prometheus_static_metric::auto_flush_from;
-use prometheus_static_metric::make_auto_flush_static_metric;
+
+use lazy_static::lazy_static;
+use prometheus_static_metric::{auto_flush_from, make_auto_flush_static_metric};
 
 make_auto_flush_static_metric! {
 
@@ -90,11 +87,6 @@ fn main() {
 
 /*
 /// Pseudo macro expanded code of make_auto_flush_static_metric_histogram
-#[macro_use]
-extern crate lazy_static;
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use std::cell::Cell;
 
 #[allow(unused_imports)]
@@ -104,6 +96,8 @@ use std::collections::HashMap;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::thread::LocalKey;
+
+use lazy_static::lazy_static;
 
 #[allow(dead_code)]
 #[allow(non_camel_case_types)]

--- a/static-metric/examples/metric_enum.rs
+++ b/static-metric/examples/metric_enum.rs
@@ -6,10 +6,8 @@ Use metric enums to reuse possible values of a label.
 
 */
 
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::{CounterVec, IntCounterVec, Opts};
+
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {

--- a/static-metric/examples/register_integration.rs
+++ b/static-metric/examples/register_integration.rs
@@ -7,14 +7,13 @@ by using the `register_static_xxx!` macro provided by this crate.
 
 */
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::exponential_buckets;
-use prometheus_static_metric::*;
+
+use lazy_static::lazy_static;
+use prometheus::{register_counter_vec, register_histogram_vec};
+use prometheus_static_metric::{
+    make_static_metric, register_static_counter_vec, register_static_histogram_vec,
+};
 
 make_static_metric! {
     pub struct HttpRequestStatistics: Counter {

--- a/static-metric/examples/simple.rs
+++ b/static-metric/examples/simple.rs
@@ -1,9 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::{CounterVec, Opts};
+
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {

--- a/static-metric/examples/with_lazy_static.rs
+++ b/static-metric/examples/with_lazy_static.rs
@@ -1,12 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::CounterVec;
+
+use lazy_static::lazy_static;
+use prometheus::register_counter_vec;
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {

--- a/static-metric/src/auto_flush_builder.rs
+++ b/static-metric/src/auto_flush_builder.rs
@@ -7,6 +7,8 @@ use proc_macro2::{Span, TokenStream as Tokens};
 use quote::{ToTokens, TokenStreamExt};
 use syn::{Ident, Visibility};
 
+use quote::quote;
+
 use super::parser::*;
 use super::util;
 use crate::builder::TokensBuilder;

--- a/static-metric/src/auto_flush_from.rs
+++ b/static-metric/src/auto_flush_from.rs
@@ -6,6 +6,8 @@ use syn::parse::{Parse, ParseStream};
 use syn::token::*;
 use syn::*;
 
+use quote::quote;
+
 pub struct AutoFlushFromDef {
     class_name: Ident,
     inner_class_name: Ident,

--- a/static-metric/src/builder.rs
+++ b/static-metric/src/builder.rs
@@ -7,6 +7,8 @@ use proc_macro2::{Span, TokenStream as Tokens};
 use quote::TokenStreamExt;
 use syn::{Ident, Visibility};
 
+use quote::quote;
+
 use super::parser::*;
 use super::util;
 

--- a/static-metric/src/lib.rs
+++ b/static-metric/src/lib.rs
@@ -6,9 +6,10 @@ This crate provides staticly built metrics to your Prometheus application.
 This is useful since it reduces the amount of branching and processing needed at runtime to collect metrics.
 
 ```rust
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate prometheus;
 use prometheus::{self, IntCounter, TextEncoder, Encoder};
+
+use lazy_static::lazy_static;
+use prometheus::register_int_counter;
 
 lazy_static! {
     static ref HIGH_FIVE_COUNTER: IntCounter =
@@ -21,14 +22,6 @@ assert_eq!(HIGH_FIVE_COUNTER.get(), 1);
 
 Is it reccomended that you consult the [`prometheus` documentation for more information.](https://docs.rs/prometheus/)
 */
-
-extern crate lazy_static;
-extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-extern crate syn;
-
 mod auto_flush_builder;
 mod auto_flush_from;
 mod builder;

--- a/static-metric/src/register_macro.rs
+++ b/static-metric/src/register_macro.rs
@@ -5,6 +5,8 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::*;
 
+use quote::quote;
+
 /// Matches `register_static_xxx_vec!(static_struct_name, name, desc, labels, ...)`.
 pub struct RegisterMethodInvoking {
     static_struct_name: Ident,

--- a/static-metric/tests/label_enum.rs
+++ b/static-metric/tests/label_enum.rs
@@ -1,8 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {

--- a/static-metric/tests/metric.rs
+++ b/static-metric/tests/metric.rs
@@ -1,8 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-extern crate prometheus;
-extern crate prometheus_static_metric;
-
 use prometheus::core::Collector;
 use prometheus::{Counter, CounterVec, Opts};
 use prometheus_static_metric::make_static_metric;


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

`macro_use` and `extern crate` are no longer needed in 99% of circumstances. So I clean up them to make sure it's more consistent, more flexible, and easier to look up the macro definition. You can check [Path clarity](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html) for more detials.
