### PR TITLE
Allow creating a GenericGaugeVec with Vec<String>

### DIFF
--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -151,12 +151,20 @@ impl<P: Atomic> GenericGaugeVec<P> {
     /// Create a new [`GenericGaugeVec`] based on the provided
     /// [`Opts`] and partitioned by the given label names. At least one label name must
     /// be provided.
-    pub fn new(opts: Opts, label_names: &[&str]) -> Result<Self> {
-        let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
-        let opts = opts.variable_labels(variable_names);
+    pub fn new_from_vec(opts: Opts, label_names: Vec<String>) -> Result<Self> {
+        let opts = opts.variable_labels(label_names);
         let metric_vec = MetricVec::create(proto::MetricType::GAUGE, GaugeVecBuilder::new(), opts)?;
 
         Ok(metric_vec as Self)
+    }
+
+    /// Create a new [`GenericGaugeVec`] based on the provided
+    /// [`Opts`] and partitioned by the given label names. At least one label name must
+    /// be provided.
+    pub fn new(opts: Opts, label_names: &[&str]) -> Result<Self> {
+        let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
+        
+        Self::new_from_vec(opts, variable_names)
     }
 }
 


### PR DESCRIPTION
`GenericGaugeVec::new`'s need for `&[&str]` can lead to inefficient code such as what can be seen [here](https://github.com/graphprotocol/graph-node/blob/ef2a492da256205416b28e1e53265037a1031e2d/graph/src/components/metrics/mod.rs#L99) in The Graph's code, where a `Vec<&str>` is obtained from a `Vec<String>`, which is then sent as a slice to `GenericGaugeVec::new`, who clones the contents of the slice in order to again obtain a `Vec<String>`.

All those allocations could be avoided if there were a way of creating `GenericGaugeVec` with a `Vec<String>` directly, which is what this PR proposes.

The usage of `GenericGaugeVec::new` remains intact while a `GenericGaugeVec::new_from_vec` function has been added