### PR TITLE
Avoid panics from `Instant::elapsed`

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -517,7 +517,8 @@ impl Instant {
 
     pub fn elapsed(&self) -> Duration {
         match &*self {
-            Instant::Monotonic(i) => i.elapsed(),
+            // We use `saturating_duration_since` to avoid panics caused by non-monotonic clocks.
+            Instant::Monotonic(i) => StdInstant::now().saturating_duration_since(*i),
 
             // It is different from `Instant::Monotonic`, the resolution here is millisecond.
             // The processors in an SMP system do not start all at exactly the same time


### PR DESCRIPTION
To prevent timers from panicking when observed, this PR modifies the `HistogramTimer` to use saturating arithmetic.

The docs for [`std::time::Instant::elapsed`](https://doc.rust-lang.org/std/time/struct.Instant.html#method.elapsed) note that it can panic if clock monotonicity is violated. Further, the source for `Instant::now` notes that buggy clocks on various platforms have caused issues:

https://github.com/rust-lang/rust/blob/fe1c942eee3489743d655d81ca89166217db0547/library/std/src/time.rs#L223-L250

I recently observed a panic caused by a monotonicity violation in a virtualised environment. There's a full backtrace available here: https://github.com/sigp/lighthouse/issues/2485

The alternative to saturating arithmetic would be to use checked arithmetic and avoid updating the histogram in the case of a failure. However I noticed that the coarse timer saturates to 0, so figured it would be best to keep the two consistent.

If I can isolate the issue on that virtualised environment I will also file a bug report with upstream Rust.