### PR TITLE
prometheus: release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.0
+
+- Bug fix: Avoid panics from `Instant::elapsed` (#406)
+
+- Improvement: Allow trailing comma on macros (#390)
+
+- Improvement: Add macros for custom registry (#396)
+
+- Improvement: Export thread count from `process_collector` (#401)
+
+- Improvement: Add convenience TextEncoder functions to encode directly to string (#402)
+
+- Internal change: Clean up the use of macro_use and extern crate (#398)
+
+- Internal change: Update dependencies
+
 ## 0.12.0
 
  - Improvement: Fix format string in panic!() calls (#391)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-version = "0.12.0"
+version = "0.13.0"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }


### PR DESCRIPTION
## 0.13.0

- Bug fix: Avoid panics from `Instant::elapsed` (#406)

- Improvement: Allow trailing comma on macros (#390)

- Improvement: Add macros for custom registry (#396)

- Improvement: Export thread count from `process_collector` (#401)

- Improvement: Add convenience TextEncoder functions to encode directly to string (#402)

- Internal change: Clean up the use of macro_use and extern crate (#398)

- Internal change: Update dependencies

Closes: https://github.com/tikv/rust-prometheus/issues/414