### PR TITLE
Fix crates.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/tikv/rust-prometheus.svg?branch=master)](https://travis-ci.org/pingcap/rust-prometheus)
 [![docs.rs](https://docs.rs/prometheus/badge.svg)](https://docs.rs/prometheus)
-[![crates.io](http://meritbadge.herokuapp.com/prometheus)](https://crates.io/crates/prometheus)
+[![crates.io](https://img.shields.io/crates/v/prometheus.svg)](https://crates.io/crates/prometheus)
 
 This is the [Rust](https://www.rust-lang.org) client library for
 [Prometheus](http://prometheus.io). The main data structures and APIs are ported


### PR DESCRIPTION
Not sure what happened to http://meritbadge.herokuapp.com, but it's not running anymore and points to default heroku error page. 

Sheilds.io has a crates.io integration, so this should just work out of the box. 

```
![crates.io](https://img.shields.io/crates/v/$CRATE.svg)
```

Example [![crates.io](https://img.shields.io/crates/v/prometheus.svg)](https://crates.io/crates/prometheus)