### PR TITLE
prometheus: release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.13.1
+
+- Improvement: ProcessCollector use IntGauge to provide better performance (#430)
+
+- Bug fix: Fix re-export of TEXT_FORMAT to not require protobuf (#416)
+
+- Bug fix: Fix doc for encode (#433)
+
+- Bug fix: Fix broken doc links (#426)
+
+- Bug fix: Fix crates.io badge (#436)
+
+- Internal change: Derive default instead of obvious manual impl (#437)
+
+- Internal change: Remove needless borrow (#427)
+
+- Internal change: Update dependencies
+
 ## 0.13.0
 
 - Bug fix: Avoid panics from `Instant::elapsed` (#406)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-version = "0.13.0"
+version = "0.13.1"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }


### PR DESCRIPTION
## 0.13.1

- Improvement: ProcessCollector use IntGauge to provide better performance (#430)

- Bug fix: Fix re-export of TEXT_FORMAT to not require protobuf (#416)

- Bug fix: Fix doc for encode (#433)

- Bug fix: Fix broken doc links (#426)

- Bug fix: Fix crates.io badge (#436)

- Internal change: Derive default instead of obvious manual impl (#437)

- Internal change: Remove needless borrow (#427)

- Internal change: Update dependencies

Closes: https://github.com/tikv/rust-prometheus/issues/439