### PR TITLE
process_collector: fix compilation on 32-bit targets

### DIFF
--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -190,14 +190,14 @@ lazy_static! {
     static ref CLK_TCK: i64 = {
         unsafe {
             libc::sysconf(libc::_SC_CLK_TCK)
-        }
+        }.into()
     };
 
     // getconf PAGESIZE
     static ref PAGESIZE: i64 = {
         unsafe {
             libc::sysconf(libc::_SC_PAGESIZE)
-        }
+        }.into()
     };
 }
 


### PR DESCRIPTION
The crate didn't compile on 32-bit targets any more due to `libc::sysconf()` returning a 32-bit value on those targets.

Fixes #442 