### PR TITLE
Add `GenericCounter::set()` operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.4 (unreleased)
+
+- Add: `GenericCounter::set()` operation (#471)
+
 ## 0.13.3
 
 - Bug fix: Prevent ProcessCollector underflow with CPU time counter (#465)


### PR DESCRIPTION
## Synopsis

I've written the [`metrics-prometheus` crate](https://docs.rs/metrics-prometheus), trying to pave the way for uniting ecosystems of `prometheus` and `metrics` crates. While being somewhat complete, there are still minor issues which I cannot resolve (at least I didn't find a way) without making contributions to upstream.

One of them is that [`metrics::CounterFn` interface provides `absolute()` operation](https://docs.rs/metrics/0.20/metrics/trait.CounterFn.html#tymethod.absolute), while `prometheus::GenericCounter`'s API doesn't provide a way to [implement it atomically](https://docs.rs/metrics-prometheus/0.3.0/src/metrics_prometheus/metric.rs.html#53-63).

## Solution

This PR adds `GenericCounter::set()` operation, allowing to cover this use case.

## Checklist

- [x] Documentation added
- [x] Tests are added 
- [x] CHANGELOG entry is added