### PR TITLE
Allow into/from inner `Arc` conversions

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -16,6 +16,7 @@ use crate::vec::{MetricVec, MetricVecBuilder};
 
 /// The underlying implementation for [`Counter`] and [`IntCounter`].
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct GenericCounter<P: Atomic> {
     v: Arc<Value<P>>,
 }
@@ -84,6 +85,36 @@ impl<P: Atomic> GenericCounter<P> {
     /// Return a [`GenericLocalCounter`] for single thread usage.
     pub fn local(&self) -> GenericLocalCounter<P> {
         GenericLocalCounter::new(self.clone())
+    }
+
+    /// Unwraps this counter into the inner [`Value`] representing it.
+    ///
+    /// # Safety
+    ///
+    /// This function is `unsafe`, because allows to bypass counter's semantics,
+    /// and so, the improper use of the returned [`Value`] may lead to this
+    /// counter behaving incorrectly.
+    ///
+    /// The caller must ensure that the returned [`Value`] will be used in
+    /// accordance with the counter's semantics.
+    #[inline]
+    pub unsafe fn into_arc_value(this: Self) -> Arc<Value<P>> {
+        this.v
+    }
+
+    /// Wraps the provided [`Value`] into a counter.
+    ///
+    /// # Safety
+    ///
+    /// This function is `unsafe`, because allows to bypass counter's semantics,
+    /// and so, specifying the improper [`Value`] may lead to the counter
+    /// behaving incorrectly.
+    ///
+    /// The caller must ensure that the provided [`Value`] withholds counter's
+    /// semantics.
+    #[inline]
+    pub unsafe fn from_arc_value(v: impl Into<Arc<Value<P>>>) -> Self {
+        Self { v: v.into() }
     }
 }
 

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -14,6 +14,7 @@ use crate::vec::{MetricVec, MetricVecBuilder};
 
 /// The underlying implementation for [`Gauge`] and [`IntGauge`].
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct GenericGauge<P: Atomic> {
     v: Arc<Value<P>>,
 }
@@ -87,6 +88,36 @@ impl<P: Atomic> GenericGauge<P> {
     #[inline]
     pub fn get(&self) -> P::T {
         self.v.get()
+    }
+
+    /// Unwraps this gauge into the inner [`Value`] representing it.
+    ///
+    /// # Safety
+    ///
+    /// This function is `unsafe`, because allows to bypass gauge's semantics,
+    /// and so, the improper use of the returned [`Value`] may lead to this
+    /// gauge behaving incorrectly.
+    ///
+    /// The caller must ensure that the returned [`Value`] will be used in
+    /// accordance with the gauge's semantics.
+    #[inline]
+    pub unsafe fn into_arc_value(this: Self) -> Arc<Value<P>> {
+        this.v
+    }
+
+    /// Wraps the provided [`Value`] into a gauge.
+    ///
+    /// # Safety
+    ///
+    /// This function is `unsafe`, because allows to bypass gauge's semantics,
+    /// and so, specifying the improper [`Value`] may lead to the gauge behaving
+    /// incorrectly.
+    ///
+    /// The caller must ensure that the provided [`Value`] withholds gauge's
+    /// semantics.
+    #[inline]
+    pub unsafe fn from_arc_value(v: impl Into<Arc<Value<P>>>) -> Self {
+        Self { v: v.into() }
     }
 }
 

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -667,6 +667,7 @@ impl Drop for HistogramTimer {
 /// [1]: https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
 /// [2]: https://prometheus.io/docs/practices/histograms/
 #[derive(Clone, Debug)]
+#[repr(transparent)]
 pub struct Histogram {
     core: Arc<HistogramCore>,
 }
@@ -745,6 +746,18 @@ impl Histogram {
     /// Return count of all samples.
     pub fn get_sample_count(&self) -> u64 {
         self.core.sample_count()
+    }
+
+    /// Unwraps this [`Histogram`] into the inner [`HistogramCore`].
+    #[inline]
+    pub fn into_arc_core(this: Self) -> Arc<HistogramCore> {
+        this.core
+    }
+
+    /// Wraps the provided [`HistogramCore`] into a [`Histogram`].
+    #[inline]
+    pub fn from_arc_core(core: impl Into<Arc<HistogramCore>>) -> Self {
+        Self { core: core.into() }
     }
 }
 


### PR DESCRIPTION
## Overview

This PR adds:
- `into_arc_value()` and `from_arc_value()` methods to `GenericCounter` and `GenericGauge` types. These methods are `unsafe` as allow bypassing counter/gauge semantics.
- `into_arc_core()` and `from_arc_core()` methods to `Histogram` type. These methods are safe, as the `HistogramCore` public API doesn't allow bypassing `Histogram` semantics in any way.
- `#[repr(transparent)]` attribute to `GenericCounter`, `GenericGauge` and `Histogram`, so they can be safely transmuted into its inner `Arc` and back.

## Motivation

While implementing the [`metrics-prometheus` crate](https://docs.rs/metrics-prometheus), I have the situation where the [`metrics` crate requires the returned metric being `Arc`-wrapped](https://docs.rs/metrics/0.20.1/metrics/struct.Counter.html#method.from_arc) (because [returns to users `Arc<dyn Trait>` essentially](https://docs.rs/metrics/0.20.1/src/metrics/handles.rs.html#55)), and so, pushing me to introduce a [completely redundant allocation on the hot path accessing the metric](https://docs.rs/metrics-prometheus/0.3.0/src/metrics_prometheus/recorder/frozen.rs.html#217), because `prometheus` metric types have `Arc`ed semantics anyway.

First, I've tried to approach this on the `metrics` crate's side, but had no luck, as its API returns `Arc<dyn Trait>` to user code, so creating an `Arc` cannot be really bypassed here.

Then, I've looked at `prometheus` metric type's structure and realized that I can unwrap it into its inner `Arc`, and then, in the `Trait` implementation, wrap back into the original metric type. The whole thing doesn't leave the library boundary, so users won't be able to misuse the unwrapped `Arc`s anyhow.

As the bonus, it will allow me to solve the synchronization issue from #471, but without exposing safe APIs to `prometheus` users which do not follow metric type's semantics.

## Notes

- I did intentionally use `this: Self` argument instead of just `self` in `into*` methods, mimicking the [`Arc::into_raw()`](https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.into_raw), to additionally discourage library users from using those methods.

## Checklist

- [x] Documentation added
- [x] ~~Tests are added~~ (do we need ones here?)
- [ ] CHANGELOG entry is added
