### PR TITLE
pulling_gauge: fix build with --no-default-features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,8 @@ jobs:
         run: cargo build
       - name: cargo test
         run: cargo test
+      - name: cargo test (no default features)
+        run: cargo test --no-default-features
       - name: cargo test (extra features)
         run: cargo test --no-default-features --features="${{ env['EXTRA_FEATURES'] }}"
       - name: cargo package
@@ -72,6 +74,8 @@ jobs:
           default: true
       - run: cargo build
       - run: cargo test --no-run
+      - run: cargo build --no-default-features
+      - run: cargo test --no-default-features --no-run
       - run: cargo build --no-default-features --features="${{ env['EXTRA_FEATURES'] }}"
       - run: cargo test --no-default-features --features="${{ env['EXTRA_FEATURES'] }}"
   linting:
@@ -90,6 +94,10 @@ jobs:
         run: cargo fmt --all -- --check -l
       - name: cargo clippy
         run: cargo clippy --all
+      - name: cargo clippy (no default features)
+        run: cargo clippy --all --no-default-features
+      - name: cargo clippy (extra features)
+        run: cargo clippy --all --no-default-features --features="${{ env['EXTRA_FEATURES'] }}"
   criterion:
     name: "Benchmarks (criterion)"
     runs-on: ubuntu-latest

--- a/src/pulling_gauge.rs
+++ b/src/pulling_gauge.rs
@@ -4,7 +4,6 @@ use crate::{
     core::Collector,
     proto::{Gauge, Metric, MetricFamily, MetricType},
 };
-use protobuf::RepeatedField;
 
 /// A [Gauge] that returns the value from a provided function on every collect run.
 ///
@@ -76,7 +75,7 @@ impl Collector for PullingGauge {
         m.set_name(self.desc.fq_name.clone());
         m.set_help(self.desc.help.clone());
         m.set_field_type(MetricType::GAUGE);
-        m.set_metric(RepeatedField::from_vec(vec![self.metric()]));
+        m.set_metric(from_vec!(vec![self.metric()]));
         vec![m]
     }
 }


### PR DESCRIPTION
## Synopsis

After merging #405 the `master` [fails](https://github.com/instrumentisto/metrics-prometheus-rs/actions/runs/3751488097/jobs/6372528212#step:4:80) to build [with `--no-default-features`](https://github.com/instrumentisto/metrics-prometheus-rs/pull/3/commits/f928edd4975a7d7b8acd24029aa532462e466bfb#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R23). The regression wasn't caught by CI as it doesn't check this scenario.

## Solution

- Fix the compilation issue by using `crate::from_vec!()` in `PullingGauge` implementation (as the other metric types do).
- Add commands to check `--no-default-features` scenario on CI.