### PR TITLE
feat: export inner MetricVecBuilder structs

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -103,12 +103,14 @@ impl<P: Atomic> Metric for GenericCounter<P> {
     }
 }
 
+/// Default [`CounterVecBuilder`].
 #[derive(Debug)]
 pub struct CounterVecBuilder<P: Atomic> {
     _phantom: PhantomData<P>,
 }
 
 impl<P: Atomic> CounterVecBuilder<P> {
+    /// Create default builder.
     pub fn new() -> Self {
         Self {
             _phantom: PhantomData,

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -106,12 +106,14 @@ impl<P: Atomic> Metric for GenericGauge<P> {
     }
 }
 
+/// Default [`GaugeVecBuilder`].
 #[derive(Debug)]
 pub struct GaugeVecBuilder<P: Atomic> {
     _phantom: PhantomData<P>,
 }
 
 impl<P: Atomic> GaugeVecBuilder<P> {
+    /// Create default builder.
     pub fn new() -> Self {
         Self {
             _phantom: PhantomData,

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -776,6 +776,7 @@ impl Collector for Histogram {
     }
 }
 
+/// Default [`HistogramVecBuilder`].
 #[derive(Clone, Debug)]
 pub struct HistogramVecBuilder {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,10 +198,12 @@ pub mod core {
 
     pub use super::atomic64::*;
     pub use super::counter::{
-        GenericCounter, GenericCounterVec, GenericLocalCounter, GenericLocalCounterVec,
+        CounterVecBuilder, GenericCounter, GenericCounterVec, GenericLocalCounter,
+        GenericLocalCounterVec,
     };
     pub use super::desc::{Desc, Describer};
-    pub use super::gauge::{GenericGauge, GenericGaugeVec};
+    pub use super::gauge::{GaugeVecBuilder, GenericGauge, GenericGaugeVec};
+    pub use super::histogram::HistogramVecBuilder;
     pub use super::metrics::{Collector, Metric, Opts};
     pub use super::vec::{MetricVec, MetricVecBuilder};
 }


### PR DESCRIPTION
Signed-off-by: MrCroxx <mrcroxx@outlook.com>

This PR exports `MetricVecBuilder` types, with which users can easily build customized tools.