### PR TITLE
bump MSRV to 1.60.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   # Pinned toolchain for linting and benchmarks
   ACTIONS_LINTS_TOOLCHAIN: 1.63.0
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.57.0
+  ACTION_MSRV_TOOLCHAIN: 1.60.0
   EXTRA_FEATURES: "protobuf push process"
 
 jobs:


### PR DESCRIPTION
Bump MSRV to 1.60.0 for some dependencies requires higher toolchain version.

Signed-off-by: MrCroxx <mrcroxx@outlook.com>