### PR TITLE
ci: Update badge info to not refer to Travis CI.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
 version = "0.13.3"
 
-[badges]
-travis-ci = { repository = "pingcap/rust-prometheus" }
-
 [package.metadata.docs.rs]
 features = ["nightly"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prometheus Rust client library
 
-[![Build Status](https://travis-ci.org/tikv/rust-prometheus.svg?branch=master)](https://travis-ci.org/pingcap/rust-prometheus)
+[![Build Status](https://github.com/tikv/rust-prometheus/actions/workflows/rust.yml/badge.svg)](https://github.com/tikv/rust-prometheus/actions/workflows/rust.yml)
 [![docs.rs](https://docs.rs/prometheus/badge.svg)](https://docs.rs/prometheus)
 [![crates.io](https://img.shields.io/crates/v/prometheus.svg)](https://crates.io/crates/prometheus)
 


### PR DESCRIPTION
The support for using Travis was started in 200c362e5e58442230334d6126817fcceed47c25 and finished in bb90a19e6db8551d9a08c640f403e5ada20a49f6.