### PR TITLE
Add type alias for unsigned integer gauge

### DIFF
--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::atomic64::{Atomic, AtomicF64, AtomicI64, Number};
+use crate::core::AtomicU64;
 use crate::desc::Desc;
 use crate::errors::Result;
 use crate::metrics::{Collector, Metric, Opts};
@@ -25,6 +26,9 @@ pub type Gauge = GenericGauge<AtomicF64>;
 /// The integer version of [`Gauge`]. Provides better performance if metric values are
 /// all integers.
 pub type IntGauge = GenericGauge<AtomicI64>;
+
+/// The *unsigned* integer version of [`IntGauge`].
+pub type UIntGauge = GenericGauge<AtomicU64>;
 
 impl<P: Atomic> Clone for GenericGauge<P> {
     fn clone(&self) -> Self {
@@ -146,6 +150,9 @@ pub type GaugeVec = GenericGaugeVec<AtomicF64>;
 /// The integer version of [`GaugeVec`]. Provides better performance if metric values
 /// are all integers.
 pub type IntGaugeVec = GenericGaugeVec<AtomicI64>;
+
+/// The unsigned integer version of [`IntGaugeVec`].
+pub type UIntGaugeVec = GenericGaugeVec<AtomicU64>;
 
 impl<P: Atomic> GenericGaugeVec<P> {
     /// Create a new [`GenericGaugeVec`] based on the provided

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -4,8 +4,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use crate::atomic64::{Atomic, AtomicF64, AtomicI64, Number};
-use crate::core::AtomicU64;
+use crate::atomic64::{Atomic, AtomicF64, AtomicI64, AtomicU64, Number};
 use crate::desc::Desc;
 use crate::errors::Result;
 use crate::metrics::{Collector, Metric, Opts};

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -27,7 +27,7 @@ pub type Gauge = GenericGauge<AtomicF64>;
 /// all integers.
 pub type IntGauge = GenericGauge<AtomicI64>;
 
-/// The *unsigned* integer version of [`IntGauge`].
+/// The __unsigned__ integer version of [`IntGauge`].
 pub type UIntGauge = GenericGauge<AtomicU64>;
 
 impl<P: Atomic> Clone for GenericGauge<P> {
@@ -151,7 +151,7 @@ pub type GaugeVec = GenericGaugeVec<AtomicF64>;
 /// are all integers.
 pub type IntGaugeVec = GenericGaugeVec<AtomicI64>;
 
-/// The unsigned integer version of [`IntGaugeVec`].
+/// The __unsigned__ integer version of [`IntGaugeVec`].
 pub type UIntGaugeVec = GenericGaugeVec<AtomicU64>;
 
 impl<P: Atomic> GenericGaugeVec<P> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ pub use self::encoder::TextEncoder;
 pub use self::encoder::PROTOBUF_FORMAT;
 pub use self::encoder::TEXT_FORMAT;
 pub use self::errors::{Error, Result};
-pub use self::gauge::{Gauge, GaugeVec, IntGauge, IntGaugeVec};
+pub use self::gauge::{Gauge, GaugeVec, IntGauge, IntGaugeVec, UIntGauge, UIntGaugeVec};
 pub use self::histogram::DEFAULT_BUCKETS;
 pub use self::histogram::{exponential_buckets, linear_buckets};
 pub use self::histogram::{Histogram, HistogramOpts, HistogramTimer, HistogramVec};


### PR DESCRIPTION
This PR exports a type of gauge for `AtomicU64`.  This is convenient when dealing with metrics that are of type `u64`.