### PR TITLE
cargo/examples: add required-features annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,11 @@ harness = false
 [[bench]]
 name = "text_encoder"
 harness = false
+
+[[example]]
+name = "example_push"
+required-features = ["push"]
+
+[[example]]
+name = "example_process_collector"
+required-features = ["process"]

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -1,6 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[cfg(all(feature = "process", target_os = "linux"))]
 fn main() {
     use std::thread;
     use std::time::Duration;
@@ -20,12 +19,4 @@ fn main() {
         buffer.clear();
         thread::sleep(Duration::from_secs(1));
     }
-}
-
-#[cfg(any(not(feature = "process"), not(target_os = "linux")))]
-fn main() {
-    println!(
-        r#"Please enable feature "process", try:
-    cargo run --features="process" --example example_process_collector"#
-    );
 }

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![cfg_attr(not(feature = "push"), allow(unused_imports, dead_code))]
-
 use std::env;
 use std::thread;
 use std::time;
@@ -25,7 +23,6 @@ lazy_static! {
     .unwrap();
 }
 
-#[cfg(feature = "push")]
 fn main() {
     let args: Vec<String> = env::args().collect();
     let program = args[0].clone();
@@ -67,12 +64,4 @@ fn main() {
     }
 
     println!("Okay, please check the Pushgateway.");
-}
-
-#[cfg(not(feature = "push"))]
-fn main() {
-    println!(
-        r#"Please enable feature "push", try:
-    cargo run --features="push" --example example_push"#
-    );
 }


### PR DESCRIPTION
Hey,

I think we could use the [required features field](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-required-features-field) in the cargo.toml to improve the general experience / error messages when trying to run an example which requires a specific feature