### PR TITLE
ci: bump MSRV to fix test jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting and benchmarks
-  ACTIONS_LINTS_TOOLCHAIN: 1.70.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.78.0
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.70.0
+  ACTION_MSRV_TOOLCHAIN: 1.74.0
   EXTRA_FEATURES: "protobuf push process"
 
 jobs:

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -183,8 +183,8 @@ impl RegistryCore {
 
         // Write out MetricFamilies sorted by their name.
         mf_by_name
-            .into_iter()
-            .map(|(_, mut m)| {
+            .into_values()
+            .map(|mut m| {
                 // Add registry namespace prefix, if any.
                 if let Some(ref namespace) = self.prefix {
                     let prefixed = format!("{}_{}", namespace, m.get_name());

--- a/static-metric/src/auto_flush_builder.rs
+++ b/static-metric/src/auto_flush_builder.rs
@@ -714,7 +714,6 @@ impl<'a> MetricBuilderContext<'a> {
                         })#local_suffix_call,
                     }
                 } else {
-                    let prev_labels_ident = prev_labels_ident;
                     quote! {
                         #name: #member_type::from(
                             #(

--- a/static-metric/src/builder.rs
+++ b/static-metric/src/builder.rs
@@ -300,7 +300,6 @@ impl<'a> MetricBuilderContext<'a> {
                         })#local_suffix_call,
                     }
                 } else {
-                    let prev_labels_ident = prev_labels_ident;
                     quote! {
                         #name: #member_type::from(
                             #(


### PR DESCRIPTION
This fixes current CI failure on `master`:
```
error: package `clap v4.5.4` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
```