### PR TITLE
cargo: bump MSRV to 1.81

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting and benchmarks
-  ACTIONS_LINTS_TOOLCHAIN: 1.78.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.81.0
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.74.0
+  ACTION_MSRV_TOOLCHAIN: 1.81.0
   EXTRA_FEATURES: "protobuf push process"
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
+rust-version = "1.81"
 version = "0.13.4"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This fixes the following CI failure:
```
error: rustc 1.78.0 is not supported by the following packages:
  litemap@0.7.5 requires rustc 1.81
  native-tls@0.2.14 requires rustc 1.80.0
  native-tls@0.2.14 requires rustc 1.80.0
  native-tls@0.2.14 requires rustc 1.80.0
  zerofrom@0.1.6 requires rustc 1.81
```

Signed-off-by: Luca BRUNO <lucab@lucabruno.net>